### PR TITLE
feat(diagnostics): add built-in operational metrics and health collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 
 ### Added
 - Exposed `MetadataEnricher` as a public, first-class configuration extension point via `metadataEnrichers` parameter in `ObservabilityFactory.Config` and overload.
+- Added `InMemoryOperationalDiagnostics` as a first-party, lightweight collector for runtime reliability metrics and health snapshots.
 - Added built-in metadata enrichers:
   - `IngestedAtEnricher`: adds `ingestedAt` timestamp (milliseconds since epoch)
   - `VersionEnricher`: adds `version` and `buildSha` for deployment tracking
   - `EnvironmentEnricher`: adds `environment` and `region` for environment-specific metadata
   - `HostEnricher`: adds `hostname` and optional `nodeId` for multi-instance deployments
   - `CorrelationIdEnricher`: adds `traceId` and `requestId` from supplier functions for distributed tracing
+- Added async diagnostics hooks for queue depth and worker state (`onAsyncQueueDepth`, `onAsyncWorkerState`) to support health/readiness reporting.
 
 ### Changed
 - Moved the `MetadataEnricher` contract to `io.github.aeshen.observability.enricher` and grouped library-provided enrichers under `io.github.aeshen.observability.enricher.builtin` for clearer SPI-versus-builtins separation.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Provides a single, type-safe entry point to emit structured events with typed co
 - [Custom Codec](#custom-codec)
 - [Extend with Custom Sinks](#extend-with-custom-sinks)
 - [Diagnostics Hooks](#diagnostics-hooks)
+- [Built-in Operational Diagnostics](#built-in-operational-diagnostics)
 - [Query SPI](#query-spi)
 - [OpenTelemetry Setup](#opentelemetry-setup)
 - [Conformance Testing](#conformance-testing)
@@ -81,7 +82,8 @@ Sinks (fan-out)      (write to Console, File, OpenTelemetry, …)
 - **Sink SPI** — register custom sinks via `SinkConfig` + `SinkRegistry`
 - **Global context injection** — `ContextProvider` merges ambient context into every event
 - **Binary payload support** — attach opaque bytes to any event
-- **Diagnostics hooks** — `ObservabilityDiagnostics` for drops, retries, batch flushes, and errors
+- **Diagnostics hooks** — `ObservabilityDiagnostics` for drops, retries, batch flushes, queue depth, worker health, and sink errors
+- **Built-in operational collector** — `InMemoryOperationalDiagnostics` provides lightweight counters and health snapshots
 - **Binary compatibility tracking** — enforced via `binary-compatibility-validator`
 - **Audit query SPI** — `query-spi` module for backend-agnostic retrieval of audit records
 
@@ -803,8 +805,40 @@ val observability =
 | `onSinkCloseError`    | A sink throws during `close()`                            |
 | `onAsyncDrop`         | An event is dropped by the async queue                    |
 | `onAsyncWorkerError`  | The async background worker throws an uncaught exception  |
+| `onAsyncQueueDepth`   | Async queue depth/capacity changes                        |
+| `onAsyncWorkerState`  | Async worker health state changes                         |
 | `onBatchFlush`        | A batch is flushed (success or failure)                   |
 | `onRetryExhaustion`   | Retry limit exceeded; last error is rethrown              |
+
+---
+
+## Built-in Operational Diagnostics
+
+Use `InMemoryOperationalDiagnostics` when you want first-party counters and health/readiness snapshots without adding heavy dependencies:
+
+```kotlin
+import io.github.aeshen.observability.ObservabilityFactory
+import io.github.aeshen.observability.config.sink.Console
+import io.github.aeshen.observability.diagnostics.InMemoryOperationalDiagnostics
+
+val operational = InMemoryOperationalDiagnostics()
+
+val observability =
+    ObservabilityFactory.create(
+        ObservabilityFactory.Config(
+            sinks = listOf(Console),
+            diagnostics = operational,
+        ),
+    )
+
+// Metrics snapshot (drops, retries, sink failures, batch outcomes, queue depth)
+val metrics = operational.metricsSnapshot()
+
+// Health snapshot (READY, DEGRADED, UNHEALTHY + async worker readiness)
+val health = operational.healthSnapshot()
+```
+
+The collector uses atomics only, keeps runtime overhead small, and works with existing sink implementations.
 
 ---
 

--- a/api/observability.api
+++ b/api/observability.api
@@ -253,10 +253,36 @@ public final class io/github/aeshen/observability/config/sink/ZipFile : io/githu
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/github/aeshen/observability/diagnostics/HealthStatus : java/lang/Enum {
+	public static final field DEGRADED Lio/github/aeshen/observability/diagnostics/HealthStatus;
+	public static final field READY Lio/github/aeshen/observability/diagnostics/HealthStatus;
+	public static final field UNHEALTHY Lio/github/aeshen/observability/diagnostics/HealthStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/aeshen/observability/diagnostics/HealthStatus;
+	public static fun values ()[Lio/github/aeshen/observability/diagnostics/HealthStatus;
+}
+
+public final class io/github/aeshen/observability/diagnostics/InMemoryOperationalDiagnostics : io/github/aeshen/observability/diagnostics/ObservabilityDiagnostics {
+	public fun <init> ()V
+	public final fun healthSnapshot ()Lio/github/aeshen/observability/diagnostics/OperationalHealthSnapshot;
+	public final fun metricsSnapshot ()Lio/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot;
+	public fun onAsyncDrop (Lio/github/aeshen/observability/codec/EncodedEvent;Ljava/lang/String;)V
+	public fun onAsyncQueueDepth (II)V
+	public fun onAsyncWorkerError (Ljava/lang/Exception;)V
+	public fun onAsyncWorkerState (ZLjava/lang/String;)V
+	public fun onBatchFlush (IJZLjava/lang/Exception;)V
+	public fun onRetryExhaustion (Lio/github/aeshen/observability/codec/EncodedEvent;ILjava/lang/Exception;)V
+	public fun onSinkCloseError (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/lang/Exception;)V
+	public fun onSinkHandleError (Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/codec/EncodedEvent;Ljava/lang/Exception;)V
+}
+
 public abstract interface class io/github/aeshen/observability/diagnostics/ObservabilityDiagnostics {
 	public static final field Companion Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics$Companion;
 	public fun onAsyncDrop (Lio/github/aeshen/observability/codec/EncodedEvent;Ljava/lang/String;)V
+	public fun onAsyncQueueDepth (II)V
 	public fun onAsyncWorkerError (Ljava/lang/Exception;)V
+	public fun onAsyncWorkerState (ZLjava/lang/String;)V
+	public static synthetic fun onAsyncWorkerState$default (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;ZLjava/lang/String;ILjava/lang/Object;)V
 	public fun onBatchFlush (IJZLjava/lang/Exception;)V
 	public fun onRetryExhaustion (Lio/github/aeshen/observability/codec/EncodedEvent;ILjava/lang/Exception;)V
 	public fun onSinkCloseError (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/lang/Exception;)V
@@ -269,11 +295,67 @@ public final class io/github/aeshen/observability/diagnostics/ObservabilityDiagn
 
 public final class io/github/aeshen/observability/diagnostics/ObservabilityDiagnostics$DefaultImpls {
 	public static fun onAsyncDrop (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/codec/EncodedEvent;Ljava/lang/String;)V
+	public static fun onAsyncQueueDepth (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;II)V
 	public static fun onAsyncWorkerError (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Ljava/lang/Exception;)V
+	public static fun onAsyncWorkerState (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;ZLjava/lang/String;)V
+	public static synthetic fun onAsyncWorkerState$default (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;ZLjava/lang/String;ILjava/lang/Object;)V
 	public static fun onBatchFlush (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;IJZLjava/lang/Exception;)V
 	public static fun onRetryExhaustion (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/codec/EncodedEvent;ILjava/lang/Exception;)V
 	public static fun onSinkCloseError (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/lang/Exception;)V
 	public static fun onSinkHandleError (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/codec/EncodedEvent;Ljava/lang/Exception;)V
+}
+
+public final class io/github/aeshen/observability/diagnostics/OperationalHealthSnapshot {
+	public fun <init> (Lio/github/aeshen/observability/diagnostics/HealthStatus;ZZLjava/lang/String;)V
+	public final fun component1 ()Lio/github/aeshen/observability/diagnostics/HealthStatus;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lio/github/aeshen/observability/diagnostics/HealthStatus;ZZLjava/lang/String;)Lio/github/aeshen/observability/diagnostics/OperationalHealthSnapshot;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/diagnostics/OperationalHealthSnapshot;Lio/github/aeshen/observability/diagnostics/HealthStatus;ZZLjava/lang/String;ILjava/lang/Object;)Lio/github/aeshen/observability/diagnostics/OperationalHealthSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsyncWorkerHealthy ()Z
+	public final fun getAsyncWorkerMessage ()Ljava/lang/String;
+	public final fun getReady ()Z
+	public final fun getStatus ()Lio/github/aeshen/observability/diagnostics/HealthStatus;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot {
+	public fun <init> (JJJJJJJJJJIII)V
+	public final fun component1 ()J
+	public final fun component10 ()J
+	public final fun component11 ()I
+	public final fun component12 ()I
+	public final fun component13 ()I
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun component6 ()J
+	public final fun component7 ()J
+	public final fun component8 ()J
+	public final fun component9 ()J
+	public final fun copy (JJJJJJJJJJIII)Lio/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot;JJJJJJJJJJIIIILjava/lang/Object;)Lio/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsyncDrops ()J
+	public final fun getAsyncQueueCapacity ()I
+	public final fun getAsyncQueueDepth ()I
+	public final fun getAsyncQueueDepthMax ()I
+	public final fun getAsyncWorkerErrors ()J
+	public final fun getAverageBatchFlushMillis ()D
+	public final fun getBatchFlushFailures ()J
+	public final fun getBatchFlushSuccesses ()J
+	public final fun getBatchFlushTotalCount ()J
+	public final fun getBatchFlushTotalElapsedMillis ()J
+	public final fun getBatchFlushedEvents ()J
+	public final fun getRetryExhaustions ()J
+	public final fun getSinkCloseErrors ()J
+	public final fun getSinkHandleErrors ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class io/github/aeshen/observability/enricher/MetadataEnricher {

--- a/src/main/kotlin/io/github/aeshen/observability/diagnostics/InMemoryOperationalDiagnostics.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/diagnostics/InMemoryOperationalDiagnostics.kt
@@ -1,0 +1,179 @@
+package io.github.aeshen.observability.diagnostics
+
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.sink.ObservabilitySink
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Lightweight, lock-free diagnostics collector for operational metrics and health snapshots.
+ */
+@Suppress("TooManyFunctions", "detekt.TooManyFunctions")
+class InMemoryOperationalDiagnostics : ObservabilityDiagnostics {
+    private val sinkHandleErrors = AtomicLong(0)
+    private val sinkCloseErrors = AtomicLong(0)
+    private val asyncDrops = AtomicLong(0)
+    private val asyncWorkerErrors = AtomicLong(0)
+    private val retryExhaustions = AtomicLong(0)
+    private val batchFlushSuccesses = AtomicLong(0)
+    private val batchFlushFailures = AtomicLong(0)
+    private val batchFlushTotalCount = AtomicLong(0)
+    private val batchFlushTotalElapsedMillis = AtomicLong(0)
+    private val batchFlushedEvents = AtomicLong(0)
+
+    private val asyncQueueDepth = AtomicInteger(0)
+    private val asyncQueueDepthMax = AtomicInteger(0)
+    private val asyncQueueCapacity = AtomicInteger(0)
+
+    private val asyncWorkerHealthy = AtomicBoolean(true)
+    private val asyncWorkerMessage = AtomicReference<String?>(null)
+
+    override fun onSinkHandleError(
+        sink: ObservabilitySink,
+        event: EncodedEvent,
+        error: Exception,
+    ) {
+        sinkHandleErrors.incrementAndGet()
+    }
+
+    override fun onSinkCloseError(
+        sink: ObservabilitySink,
+        error: Exception,
+    ) {
+        sinkCloseErrors.incrementAndGet()
+    }
+
+    override fun onAsyncDrop(
+        event: EncodedEvent,
+        reason: String,
+    ) {
+        asyncDrops.incrementAndGet()
+    }
+
+    override fun onAsyncWorkerError(error: Exception) {
+        asyncWorkerErrors.incrementAndGet()
+        asyncWorkerHealthy.set(false)
+        asyncWorkerMessage.set(error.message)
+    }
+
+    override fun onAsyncQueueDepth(
+        queueDepth: Int,
+        capacity: Int,
+    ) {
+        asyncQueueDepth.set(queueDepth)
+        asyncQueueCapacity.set(capacity)
+        asyncQueueDepthMax.accumulateAndGet(queueDepth) { current, incoming ->
+            if (incoming > current) incoming else current
+        }
+    }
+
+    override fun onAsyncWorkerState(
+        healthy: Boolean,
+        message: String?,
+    ) {
+        asyncWorkerHealthy.set(healthy)
+        asyncWorkerMessage.set(message)
+    }
+
+    override fun onBatchFlush(
+        batchSize: Int,
+        elapsedMillis: Long,
+        success: Boolean,
+        error: Exception?,
+    ) {
+        batchFlushTotalCount.incrementAndGet()
+        batchFlushTotalElapsedMillis.addAndGet(elapsedMillis)
+        batchFlushedEvents.addAndGet(batchSize.toLong())
+        if (success) {
+            batchFlushSuccesses.incrementAndGet()
+        } else {
+            batchFlushFailures.incrementAndGet()
+        }
+    }
+
+    override fun onRetryExhaustion(
+        event: EncodedEvent,
+        attempts: Int,
+        lastError: Exception,
+    ) {
+        retryExhaustions.incrementAndGet()
+    }
+
+    fun metricsSnapshot(): OperationalMetricsSnapshot =
+        OperationalMetricsSnapshot(
+            sinkHandleErrors = sinkHandleErrors.get(),
+            sinkCloseErrors = sinkCloseErrors.get(),
+            asyncDrops = asyncDrops.get(),
+            asyncWorkerErrors = asyncWorkerErrors.get(),
+            retryExhaustions = retryExhaustions.get(),
+            batchFlushSuccesses = batchFlushSuccesses.get(),
+            batchFlushFailures = batchFlushFailures.get(),
+            batchFlushTotalCount = batchFlushTotalCount.get(),
+            batchFlushTotalElapsedMillis = batchFlushTotalElapsedMillis.get(),
+            batchFlushedEvents = batchFlushedEvents.get(),
+            asyncQueueDepth = asyncQueueDepth.get(),
+            asyncQueueDepthMax = asyncQueueDepthMax.get(),
+            asyncQueueCapacity = asyncQueueCapacity.get(),
+        )
+
+    fun healthSnapshot(): OperationalHealthSnapshot {
+        val status =
+            when {
+                !asyncWorkerHealthy.get() -> HealthStatus.UNHEALTHY
+                hasReliabilitySignals() -> HealthStatus.DEGRADED
+                else -> HealthStatus.READY
+            }
+
+        return OperationalHealthSnapshot(
+            status = status,
+            ready = status != HealthStatus.UNHEALTHY,
+            asyncWorkerHealthy = asyncWorkerHealthy.get(),
+            asyncWorkerMessage = asyncWorkerMessage.get(),
+        )
+    }
+
+    private fun hasReliabilitySignals(): Boolean =
+        sinkHandleErrors.get() > 0 ||
+            sinkCloseErrors.get() > 0 ||
+            asyncDrops.get() > 0 ||
+            retryExhaustions.get() > 0 ||
+            batchFlushFailures.get() > 0
+}
+
+enum class HealthStatus {
+    READY,
+    DEGRADED,
+    UNHEALTHY,
+}
+
+data class OperationalHealthSnapshot(
+    val status: HealthStatus,
+    val ready: Boolean,
+    val asyncWorkerHealthy: Boolean,
+    val asyncWorkerMessage: String?,
+)
+
+data class OperationalMetricsSnapshot(
+    val sinkHandleErrors: Long,
+    val sinkCloseErrors: Long,
+    val asyncDrops: Long,
+    val asyncWorkerErrors: Long,
+    val retryExhaustions: Long,
+    val batchFlushSuccesses: Long,
+    val batchFlushFailures: Long,
+    val batchFlushTotalCount: Long,
+    val batchFlushTotalElapsedMillis: Long,
+    val batchFlushedEvents: Long,
+    val asyncQueueDepth: Int,
+    val asyncQueueDepthMax: Int,
+    val asyncQueueCapacity: Int,
+) {
+    val averageBatchFlushMillis: Double =
+        if (batchFlushTotalCount == 0L) {
+            0.0
+        } else {
+            batchFlushTotalElapsedMillis.toDouble() / batchFlushTotalCount.toDouble()
+        }
+}

--- a/src/main/kotlin/io/github/aeshen/observability/diagnostics/ObservabilityDiagnostics.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/diagnostics/ObservabilityDiagnostics.kt
@@ -25,6 +25,16 @@ interface ObservabilityDiagnostics {
 
     fun onAsyncWorkerError(error: Exception) = Unit
 
+    fun onAsyncQueueDepth(
+        queueDepth: Int,
+        capacity: Int,
+    ) = Unit
+
+    fun onAsyncWorkerState(
+        healthy: Boolean,
+        message: String? = null,
+    ) = Unit
+
     fun onBatchFlush(
         batchSize: Int,
         elapsedMillis: Long,

--- a/src/main/kotlin/io/github/aeshen/observability/sink/decorator/AsyncObservabilitySink.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/sink/decorator/AsyncObservabilitySink.kt
@@ -50,6 +50,11 @@ class AsyncObservabilitySink(
             start()
         }
 
+    init {
+        diagnostics.onAsyncWorkerState(healthy = true, message = "running")
+        diagnostics.onAsyncQueueDepth(queueDepth = 0, capacity = capacity)
+    }
+
     override fun handle(event: EncodedEvent) {
         val snapshot = event.copy(metadata = event.metadata.toMutableMap())
         if (!accepting.get()) {
@@ -64,10 +69,14 @@ class AsyncObservabilitySink(
         val accepted = queue.offer(snapshot, offerTimeoutMillis, TimeUnit.MILLISECONDS)
         if (!accepted) {
             diagnostics.onAsyncDrop(snapshot, DropReason.QUEUE_FULL.name)
+            diagnostics.onAsyncQueueDepth(queueDepth = queue.size, capacity = capacity)
             if (failOnDrop) {
                 error("Async sink queue is full (capacity=$capacity).")
             }
+            return
         }
+
+        diagnostics.onAsyncQueueDepth(queueDepth = queue.size, capacity = capacity)
     }
 
     override fun close() {
@@ -78,6 +87,7 @@ class AsyncObservabilitySink(
             dropped.forEach {
                 diagnostics.onAsyncDrop(it, DropReason.DROP_PENDING_ON_CLOSE.name)
             }
+            diagnostics.onAsyncQueueDepth(queueDepth = queue.size, capacity = capacity)
             worker.interrupt()
         }
 
@@ -112,6 +122,7 @@ class AsyncObservabilitySink(
         }
 
         closeFailure?.let { throw it }
+        diagnostics.onAsyncWorkerState(healthy = true, message = "stopped")
     }
 
     @Suppress("LoopWithTooManyJumpStatements")
@@ -129,8 +140,10 @@ class AsyncObservabilitySink(
 
             try {
                 delegate.handle(event)
+                diagnostics.onAsyncQueueDepth(queueDepth = queue.size, capacity = capacity)
             } catch (t: Exception) {
                 diagnostics.onAsyncWorkerError(t)
+                diagnostics.onAsyncWorkerState(healthy = false, message = t.message)
                 onWorkerFailure(t)
                 if (!accepting.get()) {
                     break

--- a/src/test/kotlin/io/github/aeshen/observability/diagnostics/InMemoryOperationalDiagnosticsTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/diagnostics/InMemoryOperationalDiagnosticsTest.kt
@@ -1,0 +1,98 @@
+package io.github.aeshen.observability.diagnostics
+
+import io.github.aeshen.observability.EventName
+import io.github.aeshen.observability.ObservabilityContext
+import io.github.aeshen.observability.ObservabilityEvent
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.sink.EventLevel
+import io.github.aeshen.observability.sink.ObservabilitySink
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InMemoryOperationalDiagnosticsTest {
+    @Test
+    fun `collector captures metrics snapshot from diagnostics hooks`() {
+        val diagnostics = InMemoryOperationalDiagnostics()
+
+        diagnostics.onSinkHandleError(NoopSink, sampleEvent(), IllegalStateException("handle"))
+        diagnostics.onSinkCloseError(NoopSink, IllegalStateException("close"))
+        diagnostics.onAsyncDrop(sampleEvent(), "QUEUE_FULL")
+        diagnostics.onAsyncQueueDepth(queueDepth = 3, capacity = 8)
+        diagnostics.onBatchFlush(batchSize = 2, elapsedMillis = 12, success = true, error = null)
+        diagnostics.onBatchFlush(
+            batchSize = 1,
+            elapsedMillis = 8,
+            success = false,
+            error = IllegalStateException("flush"),
+        )
+        diagnostics.onRetryExhaustion(
+            sampleEvent(),
+            attempts = 3,
+            lastError = IllegalStateException("retry"),
+        )
+
+        val snapshot = diagnostics.metricsSnapshot()
+
+        assertEquals(1, snapshot.sinkHandleErrors)
+        assertEquals(1, snapshot.sinkCloseErrors)
+        assertEquals(1, snapshot.asyncDrops)
+        assertEquals(1, snapshot.retryExhaustions)
+        assertEquals(1, snapshot.batchFlushSuccesses)
+        assertEquals(1, snapshot.batchFlushFailures)
+        assertEquals(2, snapshot.batchFlushTotalCount)
+        assertEquals(20, snapshot.batchFlushTotalElapsedMillis)
+        assertEquals(3, snapshot.batchFlushedEvents)
+        assertEquals(3, snapshot.asyncQueueDepth)
+        assertEquals(3, snapshot.asyncQueueDepthMax)
+        assertEquals(8, snapshot.asyncQueueCapacity)
+        assertEquals(10.0, snapshot.averageBatchFlushMillis)
+    }
+
+    @Test
+    fun `collector health is degraded when reliability signals are present`() {
+        val diagnostics = InMemoryOperationalDiagnostics()
+
+        diagnostics.onRetryExhaustion(sampleEvent(), attempts = 2, lastError = IllegalStateException("retry"))
+
+        val health = diagnostics.healthSnapshot()
+
+        assertEquals(HealthStatus.DEGRADED, health.status)
+        assertTrue(health.ready)
+        assertTrue(health.asyncWorkerHealthy)
+    }
+
+    @Test
+    fun `collector health is unhealthy when async worker reports failure`() {
+        val diagnostics = InMemoryOperationalDiagnostics()
+
+        diagnostics.onAsyncWorkerState(healthy = false, message = "worker failed")
+
+        val health = diagnostics.healthSnapshot()
+
+        assertEquals(HealthStatus.UNHEALTHY, health.status)
+        assertFalse(health.ready)
+        assertEquals("worker failed", health.asyncWorkerMessage)
+    }
+
+    private fun sampleEvent(): EncodedEvent =
+        EncodedEvent(
+            original = ObservabilityEvent(
+                name = TestEvent.TEST,
+                level = EventLevel.INFO,
+                context = ObservabilityContext.empty(),
+            ),
+            encoded = "payload".toByteArray(Charsets.UTF_8),
+        )
+
+    private object NoopSink : ObservabilitySink {
+        override fun handle(event: EncodedEvent) = Unit
+    }
+
+    private enum class TestEvent(
+        override val eventName: String? = null,
+    ) : EventName {
+        TEST("diagnostics.test"),
+    }
+}

--- a/src/test/kotlin/io/github/aeshen/observability/sink/decorator/SinkDecoratorTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/sink/decorator/SinkDecoratorTest.kt
@@ -199,6 +199,52 @@ class AsyncObservabilitySinkConformanceTest : ObservabilitySinkConformanceSuite(
     }
 
     @Test
+    fun `reports queue depth and worker state diagnostics`() {
+        val queueDepths = mutableListOf<Int>()
+        val workerStates = mutableListOf<Pair<Boolean, String?>>()
+        val release = CountDownLatch(1)
+
+        val sink =
+            AsyncObservabilitySink(
+                delegate =
+                object : ObservabilitySink {
+                    override fun handle(event: EncodedEvent) {
+                        release.await(2, TimeUnit.SECONDS)
+                    }
+                },
+                capacity = 2,
+                offerTimeoutMillis = 5,
+                diagnostics =
+                object : ObservabilityDiagnostics {
+                    override fun onAsyncQueueDepth(
+                        queueDepth: Int,
+                        capacity: Int,
+                    ) {
+                        queueDepths += queueDepth
+                    }
+
+                    override fun onAsyncWorkerState(
+                        healthy: Boolean,
+                        message: String?,
+                    ) {
+                        workerStates += healthy to message
+                    }
+                },
+            )
+
+        sink.handle(sample("one"))
+        sink.handle(sample("two"))
+        sink.handle(sample("three"))
+
+        release.countDown()
+        sink.close()
+
+        assertTrue(queueDepths.any { it > 0 })
+        assertEquals(true to "running", workerStates.first())
+        assertEquals(true to "stopped", workerStates.last())
+    }
+
+    @Test
     fun `failOnWorkerError surfaces worker failure on subsequent writes and close`() {
         val attempts = AtomicInteger(0)
         val sink =


### PR DESCRIPTION
Implement Issue #2 by adding first-party operational visibility for reliability components.

- add `InMemoryOperationalDiagnostics` to collect lightweight, lock-free runtime metrics
  - async drops
  - retry exhaustion
  - sink handle/close errors
  - batch flush success/failure, counts, and latency totals
  - async queue depth/current capacity/max depth
- add health snapshot model with status (`READY`, `DEGRADED`, `UNHEALTHY`) and async worker state
- extend `ObservabilityDiagnostics` with optional hooks:
  - `onAsyncQueueDepth(queueDepth, capacity)`
  - `onAsyncWorkerState(healthy, message)`
- instrument `AsyncObservabilitySink` to emit queue depth and worker state transitions
- add/extend tests for collector snapshots and async diagnostics emission
- update docs and changelog with usage and behavior
- update binary API baseline (`api/observability.api`)

## What changed

<!-- Briefly describe the change and why -->

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Sinks / sink decorators
- [ ] Codec / processors / encryption
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [ ] Docs

## Validation

- [x] Added/updated tests
- [x] Ran `./gradlew test`
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew detekt`
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [ ] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] `AUDIT_DURABLE` behavior reviewed when reliability logic changed

## Docs & release notes

- [ ] Updated `README.md`/docs where user-visible behavior changed
- [x] Updated `CHANGELOG.md` (if needed)
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

closes #2 
