### PR TITLE
feat(processor): add sensitive-field redaction/filtering with ordered rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 ### Added
 - Exposed `MetadataEnricher` as a public, first-class configuration extension point via `metadataEnrichers` parameter in `ObservabilityFactory.Config` and overload.
 - Added `InMemoryOperationalDiagnostics` as a first-party, lightweight collector for runtime reliability metrics and health snapshots.
+- Added first-party sensitive-field filtering via `SensitiveFieldProcessor`, ordered allow/mask/remove rules, and `SensitiveFieldPresets.commonSecrets()` for common secret/token/email-style field names.
 - Added built-in metadata enrichers:
   - `IngestedAtEnricher`: adds `ingestedAt` timestamp (milliseconds since epoch)
   - `VersionEnricher`: adds `version` and `buildSha` for deployment tracking
@@ -21,6 +22,8 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 - Moved the `MetadataEnricher` contract to `io.github.aeshen.observability.enricher` and grouped library-provided enrichers under `io.github.aeshen.observability.enricher.builtin` for clearer SPI-versus-builtins separation.
 - Evolved the optional `query-spi` module toward a typed, future-proof contract with `AuditSearchQueryService` and `AuditSearchQuery`, while retaining `AuditQueryService` as a deprecated compatibility bridge.
 - Standardized the recommended `query-spi` naming convention for dynamic query fields as `context.<key>` and `metadata.<key>`, with additive `AuditField` helpers for those namespaces.
+- Added first-class `processors` support to `ObservabilityFactory.Config` while ensuring custom processors run before encryption.
+- Standardized sink creation guidance around `ObservabilityFactory.Config.sinks` + `SinkRegistry`; kept direct sink injection as a deprecated compatibility bridge.
 
 ## [1.0.0] - 2026-03-21
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Provides a single, type-safe entry point to emit structured events with typed co
 - [Configure Encryption](#configure-encryption)
   - [AES-GCM with a fixed key](#aes-gcm-with-a-fixed-key)
   - [RSA-wrapped per-event data key](#rsa-wrapped-per-event-data-key)
+- [Sensitive Field Processors](#sensitive-field-processors)
 - [Custom Codec](#custom-codec)
 - [Extend with Custom Sinks](#extend-with-custom-sinks)
 - [Diagnostics Hooks](#diagnostics-hooks)
@@ -76,6 +77,7 @@ Sinks (fan-out)      (write to Console, File, OpenTelemetry, …)
 - **Type-safe context** — typed keys (`StringKey`, `LongKey`, `DoubleKey`, `BooleanKey`) and namespaced key grouping
 - **Multiple sinks with fan-out** — Console, SLF4J, File (JSONL), ZipFile, OpenTelemetry OTLP
 - **Optional encryption** — AES-GCM with a fixed key, or per-event data key wrapped with RSA-OAEP-256
+- **Sensitive-field filtering** — ordered allow/mask/remove processors for `context.*`, `metadata.*`, `message`, and `payload`
 - **Reliability decorators** — `AsyncObservabilitySink`, `BatchingObservabilitySink`, `RetryingObservabilitySink`
 - **Profiles** — `STANDARD` (best-effort) or `AUDIT_DURABLE` (strict, retried, batched)
 - **Pluggable codec** — default JSONL, fully replaceable
@@ -461,7 +463,7 @@ val config =
 | `ZipFile`        | Appends JSONL entries to a ZIP archive, preserving existing entries via startup replay | None                                              |
 | `OpenTelemetry`  | Exports via OTLP HTTP to any OTel-compatible backend      | `opentelemetry-api`, `-sdk`, `-exporter-otlp`     |
 
-All sinks receive fan-out delivery; a failure in one does not block others (unless `failOnSinkError = true`).
+All sinks receive fan-out delivery. `IllegalArgumentException` and `IllegalStateException` from one sink do not block others (unless `failOnSinkError = true`).
 
 ### Default JSONL Format
 
@@ -582,7 +584,7 @@ val fixedRetrySink =
 
 ### STANDARD (default)
 
-Best-effort delivery. Sink exceptions are swallowed unless `failOnSinkError = true`.
+Best-effort delivery. `IllegalArgumentException` and `IllegalStateException` from sinks are swallowed unless `failOnSinkError = true`.
 
 ### AUDIT_DURABLE
 
@@ -659,6 +661,74 @@ Encrypted output format:
 
 ---
 
+## Sensitive Field Processors
+
+Use `SensitiveFieldProcessor` to mask or remove sensitive fields before sink delivery.
+Custom processors run before built-in encryption, so redaction happens on plaintext first.
+
+### Rule model
+
+- Rules are evaluated in declaration order.
+- The **first matching rule wins**.
+- Match paths are case-insensitive and support `*` globs.
+- Common paths:
+  - `message`
+  - `payload`
+  - `context.<key>`
+  - `metadata.<key>`
+
+### Example: allow/deny rules
+
+```kotlin
+import io.github.aeshen.observability.ObservabilityFactory
+import io.github.aeshen.observability.config.sink.File
+import io.github.aeshen.observability.processor.builtin.SensitiveFieldProcessor
+import io.github.aeshen.observability.processor.builtin.SensitiveFieldRule
+import java.nio.file.Path
+
+val observability =
+    ObservabilityFactory.create(
+        ObservabilityFactory.Config(
+            sinks = listOf(File(Path.of("./logs/audit.jsonl"))),
+            processors =
+                listOf(
+                    SensitiveFieldProcessor(
+                        rules = listOf(
+                            SensitiveFieldRule.allow("context.requestId"),
+                            SensitiveFieldRule.remove("context.password"),
+                            SensitiveFieldRule.mask("context.email", "[EMAIL]"),
+                            SensitiveFieldRule.mask("metadata.apiToken", "[TOKEN]"),
+                            SensitiveFieldRule.mask("message", "[REDACTED]"),
+                            SensitiveFieldRule.remove("payload"),
+                        ),
+                    ),
+                ),
+            ),
+    )
+```
+
+### Example: built-in common-secret presets
+
+```kotlin
+import io.github.aeshen.observability.processor.builtin.SensitiveFieldPresets
+
+val processor =
+    SensitiveFieldProcessor(
+        rules = listOf(
+            SensitiveFieldRule.allow("context.apiToken"), // explicit allow wins
+        ),
+        presets = SensitiveFieldPresets.commonSecrets(mask = "[MASKED]"),
+    )
+```
+
+### Codec compatibility
+
+`SensitiveFieldProcessor` always sanitizes `EncodedEvent.original` and `EncodedEvent.metadata`.
+If the encoded payload is a UTF-8 JSON object, it also sanitizes the serialized body.
+That means it works out of the box with the default `JsonLineCodec` and with JSON-based custom codecs.
+
+---
+
 ## Custom Codec
 
 Replace the default JSONL codec with any `ObservabilityCodec` implementation:
@@ -690,13 +760,16 @@ val observability =
 
 ## Extend with Custom Sinks
 
-### Option A: Direct sink instance
+### Option A: Runtime sink instance via registry adapter
 
-Pass a sink directly; useful for testing or lightweight wiring:
+If you already have a sink instance at runtime (for example in tests), wrap it in a local `SinkConfig` and register a provider that returns the instance:
 
 ```kotlin
+import io.github.aeshen.observability.ObservabilityFactory
+import io.github.aeshen.observability.config.sink.SinkConfig
 import io.github.aeshen.observability.sink.ObservabilitySink
 import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.sink.registry.SinkRegistry
 
 class MySink : ObservabilitySink {
     override fun handle(event: EncodedEvent) {
@@ -704,7 +777,21 @@ class MySink : ObservabilitySink {
     }
 }
 
-val observability = ObservabilityFactory.create(MySink())
+data class DirectSinkConfig(val sink: ObservabilitySink) : SinkConfig
+
+val registry =
+    SinkRegistry
+        .builder()
+        .register<DirectSinkConfig> { config -> config.sink }
+        .build()
+
+val observability =
+    ObservabilityFactory.create(
+        ObservabilityFactory.Config(
+            sinks = listOf(DirectSinkConfig(MySink())),
+            sinkRegistry = registry,
+        ),
+    )
 ```
 
 ### Option B: Config-driven via SinkRegistry
@@ -1061,7 +1148,7 @@ The test suite covers:
 ## Notes
 
 - `Observability` is `Closeable`; always call `close()` or use `use { }` to flush sinks and release threads.
-- Sink failures from `Exception` are swallowed by default; set `failOnSinkError = true` for strict propagation.
+- `IllegalArgumentException` and `IllegalStateException` from sinks are swallowed by default; set `failOnSinkError = true` for strict propagation.
 - Fatal JVM `Error` types are **never** swallowed by the pipeline.
 - The default JSONL codec has no external runtime dependencies.
 - `opentelemetry-*` and `slf4j-api` are `compileOnly`; they must be on the runtime classpath of your application when those sinks are used.

--- a/api/observability.api
+++ b/api/observability.api
@@ -92,9 +92,10 @@ public final class io/github/aeshen/observability/ObservabilityFactory {
 
 public final class io/github/aeshen/observability/ObservabilityFactory$Config {
 	public static final field Companion Lio/github/aeshen/observability/ObservabilityFactory$Config$Companion;
-	public fun <init> (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;)V
-	public synthetic fun <init> (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/util/List;
 	public final fun component2 ()Lio/github/aeshen/observability/config/encryption/EncryptionConfig;
 	public final fun component3 ()Z
 	public final fun component4 ()Lio/github/aeshen/observability/sink/registry/SinkRegistry;
@@ -103,8 +104,8 @@ public final class io/github/aeshen/observability/ObservabilityFactory$Config {
 	public final fun component7 ()Ljava/util/List;
 	public final fun component8 ()Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;
 	public final fun component9 ()Lio/github/aeshen/observability/ObservabilityFactory$Profile;
-	public final fun copy (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;)Lio/github/aeshen/observability/ObservabilityFactory$Config;
-	public static synthetic fun copy$default (Lio/github/aeshen/observability/ObservabilityFactory$Config;Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;ILjava/lang/Object;)Lio/github/aeshen/observability/ObservabilityFactory$Config;
+	public final fun copy (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/util/List;)Lio/github/aeshen/observability/ObservabilityFactory$Config;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/ObservabilityFactory$Config;Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/util/List;ILjava/lang/Object;)Lio/github/aeshen/observability/ObservabilityFactory$Config;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCodec ()Lio/github/aeshen/observability/codec/ObservabilityCodec;
 	public final fun getContextProviders ()Ljava/util/List;
@@ -112,6 +113,7 @@ public final class io/github/aeshen/observability/ObservabilityFactory$Config {
 	public final fun getEncryption ()Lio/github/aeshen/observability/config/encryption/EncryptionConfig;
 	public final fun getFailOnSinkError ()Z
 	public final fun getMetadataEnrichers ()Ljava/util/List;
+	public final fun getProcessors ()Ljava/util/List;
 	public final fun getProfile ()Lio/github/aeshen/observability/ObservabilityFactory$Profile;
 	public final fun getSinkRegistry ()Lio/github/aeshen/observability/sink/registry/SinkRegistry;
 	public final fun getSinks ()Ljava/util/List;
@@ -451,6 +453,52 @@ public abstract interface class io/github/aeshen/observability/key/TypedKey {
 
 public abstract interface class io/github/aeshen/observability/processor/ObservabilityProcessor {
 	public abstract fun process (Lio/github/aeshen/observability/codec/EncodedEvent;)Lio/github/aeshen/observability/codec/EncodedEvent;
+}
+
+public final class io/github/aeshen/observability/processor/builtin/SensitiveFieldAction : java/lang/Enum {
+	public static final field ALLOW Lio/github/aeshen/observability/processor/builtin/SensitiveFieldAction;
+	public static final field MASK Lio/github/aeshen/observability/processor/builtin/SensitiveFieldAction;
+	public static final field REMOVE Lio/github/aeshen/observability/processor/builtin/SensitiveFieldAction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/aeshen/observability/processor/builtin/SensitiveFieldAction;
+	public static fun values ()[Lio/github/aeshen/observability/processor/builtin/SensitiveFieldAction;
+}
+
+public final class io/github/aeshen/observability/processor/builtin/SensitiveFieldPresets {
+	public static final field INSTANCE Lio/github/aeshen/observability/processor/builtin/SensitiveFieldPresets;
+	public final fun commonSecrets (Ljava/lang/String;)Ljava/util/List;
+	public static synthetic fun commonSecrets$default (Lio/github/aeshen/observability/processor/builtin/SensitiveFieldPresets;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/List;
+}
+
+public final class io/github/aeshen/observability/processor/builtin/SensitiveFieldProcessor : io/github/aeshen/observability/processor/ObservabilityProcessor {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun process (Lio/github/aeshen/observability/codec/EncodedEvent;)Lio/github/aeshen/observability/codec/EncodedEvent;
+}
+
+public final class io/github/aeshen/observability/processor/builtin/SensitiveFieldRule {
+	public static final field Companion Lio/github/aeshen/observability/processor/builtin/SensitiveFieldRule$Companion;
+	public fun <init> (Ljava/lang/String;Lio/github/aeshen/observability/processor/builtin/SensitiveFieldAction;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/aeshen/observability/processor/builtin/SensitiveFieldAction;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/github/aeshen/observability/processor/builtin/SensitiveFieldAction;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/github/aeshen/observability/processor/builtin/SensitiveFieldAction;Ljava/lang/String;)Lio/github/aeshen/observability/processor/builtin/SensitiveFieldRule;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/processor/builtin/SensitiveFieldRule;Ljava/lang/String;Lio/github/aeshen/observability/processor/builtin/SensitiveFieldAction;Ljava/lang/String;ILjava/lang/Object;)Lio/github/aeshen/observability/processor/builtin/SensitiveFieldRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/github/aeshen/observability/processor/builtin/SensitiveFieldAction;
+	public final fun getFieldPattern ()Ljava/lang/String;
+	public final fun getReplacement ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/aeshen/observability/processor/builtin/SensitiveFieldRule$Companion {
+	public final fun allow (Ljava/lang/String;)Lio/github/aeshen/observability/processor/builtin/SensitiveFieldRule;
+	public final fun mask (Ljava/lang/String;Ljava/lang/String;)Lio/github/aeshen/observability/processor/builtin/SensitiveFieldRule;
+	public static synthetic fun mask$default (Lio/github/aeshen/observability/processor/builtin/SensitiveFieldRule$Companion;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/aeshen/observability/processor/builtin/SensitiveFieldRule;
+	public final fun remove (Ljava/lang/String;)Lio/github/aeshen/observability/processor/builtin/SensitiveFieldRule;
 }
 
 public abstract interface class io/github/aeshen/observability/sink/BatchCapableObservabilitySink : io/github/aeshen/observability/sink/ObservabilitySink {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,8 @@ subprojects {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.10.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
     compileOnly("io.opentelemetry:opentelemetry-api:$openTelemetryVersion")
     compileOnly("io.opentelemetry:opentelemetry-sdk:$openTelemetryVersion")
     compileOnly("io.opentelemetry:opentelemetry-exporter-otlp:$openTelemetryVersion")

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -9,8 +9,9 @@ The formal compatibility policy lives in `docs/spi-contract.md`.
 - `SinkConfig` is an open interface. Third-party modules can define their own config type.
 - `SinkProvider` maps a `SinkConfig` into an `ObservabilitySink`.
 - `SinkRegistry` resolves configured sinks through registered providers.
-- `ObservabilityFactory.create(...)` supports direct sink instances.
+- `ObservabilityFactory.create(ObservabilityFactory.Config(...))` wires sinks through `SinkRegistry`.
 - `MetadataEnricher` is a stable extension point for enriching encoded events with runtime metadata.
+- `ObservabilityProcessor` is a stable extension point for byte/metadata transformations after enrichment and before sink delivery.
 
 ## Metadata Enrichers
 
@@ -93,6 +94,37 @@ Enrichers are applied in the order provided. Choose ordering carefully if enrich
 
 `MetadataEnricher.enrich()` is always called under a read lock within the emit cycle and should be fast and thread-safe. If your enricher holds state, ensure it is thread-safe (e.g., using `AtomicReference` or synchronized access).
 
+## Processors
+
+Processors run after encoding and metadata enrichment, but before sink fan-out. They can transform the encoded bytes, `EncodedEvent.original`, and `EncodedEvent.metadata`.
+
+The library now ships with a first-party `SensitiveFieldProcessor` for deterministic masking/removal of fields such as `context.password`, `metadata.apiToken`, `message`, and `payload`.
+
+### Configuration
+
+```kotlin
+import io.github.aeshen.observability.ObservabilityFactory
+import io.github.aeshen.observability.processor.builtin.SensitiveFieldProcessor
+import io.github.aeshen.observability.processor.builtin.SensitiveFieldRule
+
+val observability =
+    ObservabilityFactory.create(
+        ObservabilityFactory.Config(
+            sinks = listOf(/* ... */),
+            processors = listOf(
+                SensitiveFieldProcessor(
+                    rules = listOf(
+                        SensitiveFieldRule.remove("context.password"),
+                        SensitiveFieldRule.mask("metadata.email", "[EMAIL]"),
+                    ),
+                ),
+            ),
+        ),
+    )
+```
+
+Processors are applied in the order provided. When encryption is enabled, custom processors run before the built-in encryption processor.
+
 ## Sinks
 
 ### Threading And Lifecycle Guarantees
@@ -100,7 +132,8 @@ Enrichers are applied in the order provided. Choose ordering carefully if enrich
 - `ObservabilitySink.handle` may be called frequently and should be fast and thread-safe.
 - `ObservabilitySink.close` is called when `Observability` is closed; implementations should flush and release resources.
 - `close()` should be safe to call more than once.
-- Sink exceptions are swallowed by default unless `failOnSinkError = true`.
+- `IllegalArgumentException` and `IllegalStateException` from sinks are swallowed by default unless `failOnSinkError = true`.
+- Other exception types from `handle` are not swallowed by the pipeline.
 
 ## Error Handling Expectations
 

--- a/docs/spi-contract.md
+++ b/docs/spi-contract.md
@@ -23,13 +23,14 @@ Behavior changes to the above are treated as breaking changes.
 - `handle(event)` may be called concurrently.
 - Implementations should be thread-safe or explicitly wrapped (for example with `AsyncObservabilitySink`).
 - `close()` must release resources and be safe to call repeatedly.
-- If `handle` throws an `Exception`, pipeline behavior is controlled by `failOnSinkError`.
+- If `handle` throws `IllegalArgumentException` or `IllegalStateException`, behavior is controlled by `failOnSinkError`.
+- Other exception types from `handle` are not swallowed by the pipeline.
 - Fatal JVM `Error` types are never swallowed.
 
 ## Error Propagation Modes
 
-- `failOnSinkError = true`: sink exceptions are propagated to the caller.
-- `failOnSinkError = false`: sink exceptions are logged and processing continues.
+- `failOnSinkError = true`: handled sink exceptions are propagated to the caller.
+- `failOnSinkError = false`: handled sink exceptions are reported via `ObservabilityDiagnostics` and processing continues.
 
 ## Audit-Hardening Profile
 
@@ -85,7 +86,8 @@ The optional `query-spi` module enables backend-agnostic audit record retrieval:
 
 - Config-driven sink creation: custom `SinkConfig` + `SinkRegistry.builder().register<...> { ... }.build()`.
 - Operator diagnostics: implement `ObservabilityDiagnostics` and pass through `ObservabilityFactory.Config`.
-- Runtime instance injection: `ObservabilityFactory.create(mySink)`.
+- Runtime sink wiring: pass `SinkConfig` entries via `ObservabilityFactory.Config.sinks` and resolve through `SinkRegistry`.
+- Legacy compatibility: `ObservabilityFactory.create(vararg sinks, ...)` still exists as a deprecated bridge and is not the recommended SPI wiring path.
 - Reliability wrappers: `RetryingObservabilitySink`, `AsyncObservabilitySink`, `BatchingObservabilitySink`.
 - Audit queries: implement `AuditSearchQueryService`; expose `AuditQueryService` only as a compatibility adapter when needed.
 

--- a/src/main/kotlin/io/github/aeshen/observability/ObservabilityFactory.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/ObservabilityFactory.kt
@@ -24,6 +24,9 @@ object ObservabilityFactory {
     private const val AUDIT_MAX_ATTEMPTS = 5
     private const val AUDIT_MAX_BATCH_SIZE = 100
     private const val AUDIT_FLUSH_INTERVAL_MILLIS = 250L
+    private const val LEGACY_CREATE_DEPRECATION_MESSAGE =
+        "Use create(Config) with SinkRegistry-based sink wiring. " +
+            "This overload is kept for backward compatibility."
 
     enum class Profile {
         STANDARD,
@@ -40,6 +43,7 @@ object ObservabilityFactory {
         val metadataEnrichers: List<MetadataEnricher> = emptyList(),
         val diagnostics: ObservabilityDiagnostics = ObservabilityDiagnostics.NOOP,
         val profile: Profile = Profile.STANDARD,
+        val processors: List<ObservabilityProcessor> = emptyList(),
     ) {
         companion object {
             fun aesGcmFromRawKeyBytes(rawKey: ByteArray) =
@@ -56,17 +60,23 @@ object ObservabilityFactory {
     }
 
     fun create(config: Config): Observability {
-        val sinks: List<ObservabilitySink> = applyProfile(buildSinks(config), config.profile, config.diagnostics)
+        val sinks: List<ObservabilitySink> =
+            applyProfile(
+                buildSinks(config),
+                config.profile,
+                config.diagnostics,
+            )
 
         require(sinks.isNotEmpty()) { "At least one sink must be configured." }
 
-        val processors: List<ObservabilityProcessor> = buildProcessors(config.encryption)
+        val resolvedProcessors: List<ObservabilityProcessor> =
+            buildProcessors(config.processors, config.encryption)
 
         return ObservabilityPipeline(
             codec = config.codec,
             contextProviders = config.contextProviders,
             metadataEnrichers = config.metadataEnrichers,
-            processors = processors,
+            processors = resolvedProcessors,
             sinks = sinks,
             failOnSinkError = resolveFailOnSinkError(config.failOnSinkError, config.profile),
             diagnostics = config.diagnostics,
@@ -74,9 +84,13 @@ object ObservabilityFactory {
     }
 
     /**
-     * Advanced convenience for runtime-provided sink instances.
-     * Prefer [create] with [Config] for configuration-driven wiring.
+     * Legacy runtime-sink convenience API.
+     *
+     * Prefer [create] with [Config] and explicit [SinkRegistry] wiring.
      */
+    @Deprecated(
+        message = LEGACY_CREATE_DEPRECATION_MESSAGE,
+    )
     fun create(
         vararg sinks: ObservabilitySink,
         encryption: EncryptionConfig? = null,
@@ -87,27 +101,36 @@ object ObservabilityFactory {
         diagnostics: ObservabilityDiagnostics = ObservabilityDiagnostics.NOOP,
         profile: Profile = Profile.STANDARD,
     ): Observability {
-        val sinkList = sinks.toList()
+        val registry =
+            SinkRegistry
+                .builder()
+                .register<LegacyDirectSinkConfig> { cfg -> cfg.sink }
+                .build()
 
-        require(sinkList.isNotEmpty()) { "At least one sink must be configured." }
-
-        val processors: List<ObservabilityProcessor> = buildProcessors(encryption)
-        val profiledSinks = applyProfile(sinkList, profile, diagnostics)
-
-        return ObservabilityPipeline(
-            codec = codec,
-            contextProviders = contextProviders,
-            metadataEnrichers = metadataEnrichers,
-            processors = processors,
-            sinks = profiledSinks,
-            failOnSinkError = resolveFailOnSinkError(failOnSinkError, profile),
-            diagnostics = diagnostics,
+        return create(
+            Config(
+                sinks = sinks.map { sink -> LegacyDirectSinkConfig(sink) },
+                encryption = encryption,
+                failOnSinkError = failOnSinkError,
+                sinkRegistry = registry,
+                codec = codec,
+                contextProviders = contextProviders,
+                metadataEnrichers = metadataEnrichers,
+                diagnostics = diagnostics,
+                profile = profile,
+            ),
         )
     }
 
-    private fun buildSinks(config: Config): List<ObservabilitySink> = config.sinkRegistry.resolveAll(config.sinks)
+    private fun buildSinks(config: Config): List<ObservabilitySink> =
+        config.sinkRegistry.resolveAll(config.sinks)
 
-    private fun buildProcessors(encryption: EncryptionConfig?): List<ObservabilityProcessor> =
+    private fun buildProcessors(
+        customProcessors: List<ObservabilityProcessor>,
+        encryption: EncryptionConfig?,
+    ): List<ObservabilityProcessor> = customProcessors + buildEncryptionProcessors(encryption)
+
+    private fun buildEncryptionProcessors(encryption: EncryptionConfig?): List<ObservabilityProcessor> =
         when (val enc = encryption) {
             null -> {
                 emptyList()
@@ -138,6 +161,10 @@ object ObservabilityFactory {
         profile: Profile,
     ): Boolean = if (profile == Profile.AUDIT_DURABLE) true else explicit
 
+    private data class LegacyDirectSinkConfig(
+        val sink: ObservabilitySink,
+    ) : SinkConfig
+
     private fun applyProfile(
         sinks: List<ObservabilitySink>,
         profile: Profile,
@@ -151,8 +178,7 @@ object ObservabilityFactory {
             Profile.AUDIT_DURABLE -> {
                 sinks.map { sink ->
                     BatchingObservabilitySink(
-                        delegate =
-                        RetryingObservabilitySink(
+                        delegate = RetryingObservabilitySink(
                             delegate = sink,
                             maxAttempts = AUDIT_MAX_ATTEMPTS,
                             diagnostics = diagnostics,

--- a/src/main/kotlin/io/github/aeshen/observability/processor/builtin/SensitiveFieldProcessor.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/processor/builtin/SensitiveFieldProcessor.kt
@@ -1,0 +1,360 @@
+package io.github.aeshen.observability.processor.builtin
+
+import io.github.aeshen.observability.ObservabilityContext
+import io.github.aeshen.observability.ObservabilityEvent
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.key.TypedKey
+import io.github.aeshen.observability.processor.ObservabilityProcessor
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+private const val DEFAULT_MASK_VALUE = "[REDACTED]"
+private const val CONTEXT_PREFIX = "context."
+private const val METADATA_PREFIX = "metadata."
+private const val MESSAGE_PATH = "message"
+private const val PAYLOAD_PATH = "payload"
+private const val PAYLOAD_PRESENT_PATH = "payloadPresent"
+private const val PAYLOAD_BASE64_PATH = "payloadBase64"
+
+/**
+ * Ordered rule action for [SensitiveFieldProcessor].
+ *
+ * The processor evaluates rules in declaration order and stops at the first match.
+ */
+enum class SensitiveFieldAction {
+    ALLOW,
+    MASK,
+    REMOVE,
+}
+
+/**
+ * Rule descriptor used by [SensitiveFieldProcessor].
+ *
+ * [fieldPattern] accepts `*` globs and is matched case-insensitively against field paths such as:
+ * - `message`
+ * - `payload`
+ * - `context.password`
+ * - `metadata.apiToken`
+ */
+data class SensitiveFieldRule(
+    val fieldPattern: String,
+    val action: SensitiveFieldAction,
+    val replacement: String = DEFAULT_MASK_VALUE,
+) {
+    init {
+        require(fieldPattern.isNotBlank()) { "fieldPattern must not be blank." }
+    }
+
+    companion object {
+        fun allow(fieldPattern: String): SensitiveFieldRule =
+            SensitiveFieldRule(
+                fieldPattern = fieldPattern,
+                action = SensitiveFieldAction.ALLOW,
+            )
+
+        fun mask(
+            fieldPattern: String,
+            replacement: String = DEFAULT_MASK_VALUE,
+        ): SensitiveFieldRule =
+            SensitiveFieldRule(
+                fieldPattern = fieldPattern,
+                action = SensitiveFieldAction.MASK,
+                replacement = replacement,
+            )
+
+        fun remove(fieldPattern: String): SensitiveFieldRule =
+            SensitiveFieldRule(
+                fieldPattern = fieldPattern,
+                action = SensitiveFieldAction.REMOVE,
+            )
+    }
+}
+
+/**
+ * Ready-made rule bundles for common sensitive field names.
+ */
+object SensitiveFieldPresets {
+    fun commonSecrets(mask: String = DEFAULT_MASK_VALUE): List<SensitiveFieldRule> =
+        listOf(
+            "$CONTEXT_PREFIX*password*",
+            "$CONTEXT_PREFIX*passwd*",
+            "$CONTEXT_PREFIX*secret*",
+            "$CONTEXT_PREFIX*token*",
+            "$CONTEXT_PREFIX*authorization*",
+            "$CONTEXT_PREFIX*credential*",
+            "$CONTEXT_PREFIX*cookie*",
+            "$CONTEXT_PREFIX*session*",
+            "$CONTEXT_PREFIX*api*key*",
+            "$CONTEXT_PREFIX*email*",
+            "$METADATA_PREFIX*password*",
+            "$METADATA_PREFIX*passwd*",
+            "$METADATA_PREFIX*secret*",
+            "$METADATA_PREFIX*token*",
+            "$METADATA_PREFIX*authorization*",
+            "$METADATA_PREFIX*credential*",
+            "$METADATA_PREFIX*cookie*",
+            "$METADATA_PREFIX*session*",
+            "$METADATA_PREFIX*api*key*",
+            "$METADATA_PREFIX*email*",
+        ).map { SensitiveFieldRule.mask(it, mask) }
+}
+
+/**
+ * First-party processor for deterministic masking/removal of sensitive fields.
+ *
+ * The processor always sanitizes:
+ * - `EncodedEvent.original` for `message`, `payload`, and `context.*`
+ * - `EncodedEvent.metadata` for `metadata.*`
+ *
+ * When the encoded payload is a UTF-8 JSON object, it also sanitizes matching JSON fields.
+ * This makes it work out of the box with the default JSONL codec and JSON-based custom codecs.
+ */
+class SensitiveFieldProcessor(
+    rules: List<SensitiveFieldRule> = emptyList(),
+    presets: List<SensitiveFieldRule> = emptyList(),
+    private val json: Json = Json,
+) : ObservabilityProcessor {
+    private val compiledRules = (rules + presets).map { CompiledRule(it) }
+
+    override fun process(event: EncodedEvent): EncodedEvent {
+        if (compiledRules.isEmpty()) {
+            return event
+        }
+
+        return event.copy(
+            original = sanitizeOriginal(event.original),
+            encoded = sanitizeEncoded(event.encoded),
+            metadata = sanitizeMetadata(event.metadata),
+        )
+    }
+
+    private fun sanitizeOriginal(event: ObservabilityEvent): ObservabilityEvent {
+        val sanitizedContext = ObservabilityContext.builder()
+        event.context.asMap().forEach { (key, value) ->
+            when (val rule = resolveRule("$CONTEXT_PREFIX${key.keyName}")) {
+                null,
+                is CompiledRule.Allow,
+                -> sanitizedContext.putUntyped(key, value)
+                is CompiledRule.Mask -> sanitizedContext.putUntyped(key, rule.replacement)
+                is CompiledRule.Remove -> Unit
+            }
+        }
+
+        return ObservabilityEvent(
+            name = event.name,
+            level = event.level,
+            timestamp = event.timestamp,
+            payload = sanitizePayload(event.payload),
+            message = sanitizeString(MESSAGE_PATH, event.message),
+            context = sanitizedContext.build(),
+            error = event.error,
+        )
+    }
+
+    private fun sanitizePayload(payload: ByteArray?): ByteArray? {
+        if (payload == null) {
+            return null
+        }
+
+        return when (val rule = resolveRule(PAYLOAD_PATH)) {
+            null,
+            is CompiledRule.Allow,
+            -> payload.copyOf()
+            is CompiledRule.Mask -> rule.replacement.toByteArray(Charsets.UTF_8)
+            is CompiledRule.Remove -> null
+        }
+    }
+
+    private fun sanitizeString(
+        path: String,
+        value: String?,
+    ): String? {
+        if (value == null) {
+            return null
+        }
+
+        return when (val rule = resolveRule(path)) {
+            null,
+            is CompiledRule.Allow,
+            -> value
+            is CompiledRule.Mask -> rule.replacement
+            is CompiledRule.Remove -> null
+        }
+    }
+
+    private fun sanitizeMetadata(metadata: Map<String, Any?>): MutableMap<String, Any?> {
+        val sanitized = linkedMapOf<String, Any?>()
+        metadata.forEach { (key, value) ->
+            when (val rule = resolveRule("$METADATA_PREFIX$key")) {
+                null,
+                is CompiledRule.Allow,
+                -> sanitized[key] = value
+                is CompiledRule.Mask -> sanitized[key] = rule.replacement
+                is CompiledRule.Remove -> Unit
+            }
+        }
+        return sanitized
+    }
+
+    private fun sanitizeEncoded(encoded: ByteArray): ByteArray {
+        val raw = encoded.toString(Charsets.UTF_8)
+        val hasTrailingNewline = raw.endsWith("\n")
+        val body = if (hasTrailingNewline) raw.dropLast(1) else raw
+        val root = runCatching { json.parseToJsonElement(body) }.getOrNull() as? JsonObject ?: return encoded
+        val sanitized = sanitizeJsonObject(root)
+        val rendered = json.encodeToString(JsonElement.serializer(), sanitized)
+        return (rendered + if (hasTrailingNewline) "\n" else "").toByteArray(Charsets.UTF_8)
+    }
+
+    private fun sanitizeJsonObject(
+        obj: JsonObject,
+        parentPath: String = "",
+    ): JsonObject =
+        buildJsonObject {
+            obj.forEach { (key, value) ->
+                sanitizeJsonEntry(
+                    key = key,
+                    path = if (parentPath.isEmpty()) key else "$parentPath.$key",
+                    value = value,
+                )?.let { (entryKey, entryValue) ->
+                    put(entryKey, entryValue)
+                }
+            }
+        }
+
+    private fun sanitizeJsonEntry(
+        key: String,
+        path: String,
+        value: JsonElement,
+    ): Pair<String, JsonElement>? {
+        payloadPresenceOverride(key)?.let { return key to it }
+
+        return when (val rule = resolveRule(path)) {
+            null -> sanitizeJsonValue(path, value)?.let { key to it }
+            is CompiledRule.Allow -> key to value
+            is CompiledRule.Mask -> key to JsonPrimitive(rule.replacement)
+            is CompiledRule.Remove -> null
+        }
+    }
+
+    private fun payloadPresenceOverride(key: String): JsonPrimitive? {
+        if (key != PAYLOAD_PRESENT_PATH) {
+            return null
+        }
+
+        return when (resolveRule(PAYLOAD_PATH)) {
+            is CompiledRule.Remove -> JsonPrimitive(false)
+            is CompiledRule.Allow,
+            is CompiledRule.Mask,
+            null,
+            -> null
+        }
+    }
+
+    private fun sanitizeJsonValue(
+        path: String,
+        value: JsonElement,
+    ): JsonElement? {
+        val rule = resolveRule(path)
+        return when (value) {
+            is JsonObject -> sanitizeJsonObject(value, path)
+            JsonNull -> JsonNull
+            else -> when (rule) {
+                is CompiledRule.Remove -> null
+                is CompiledRule.Mask -> JsonPrimitive(rule.replacement)
+                is CompiledRule.Allow,
+                null,
+                -> value
+            }
+        }
+    }
+
+    private fun resolveRule(path: String): CompiledRule? {
+        val normalizedPath = normalize(path)
+        val alias = aliasFor(normalizedPath)
+        return compiledRules.firstOrNull { rule ->
+            rule.matches(normalizedPath) || rule.matches(alias)
+        }
+    }
+
+    private fun aliasFor(path: String): String =
+        when (path) {
+            PAYLOAD_BASE64_PATH, PAYLOAD_PRESENT_PATH -> PAYLOAD_PATH
+            else -> path
+        }
+
+    private fun normalize(path: String): String = path.trim().lowercase()
+
+    @Suppress("UNCHECKED_CAST")
+    private fun ObservabilityContext.Builder.putUntyped(
+        key: TypedKey<*>,
+        value: Any?,
+    ): ObservabilityContext.Builder = this.put(key as TypedKey<Any?>, value)
+
+    private sealed interface CompiledRule {
+        fun matches(path: String): Boolean
+
+        class Allow(
+            private val matcher: Regex,
+        ) : CompiledRule {
+            override fun matches(path: String): Boolean = matcher.matches(path)
+        }
+
+        class Mask(
+            private val matcher: Regex,
+            val replacement: String,
+        ) : CompiledRule {
+            override fun matches(path: String): Boolean = matcher.matches(path)
+        }
+
+        class Remove(
+            private val matcher: Regex,
+        ) : CompiledRule {
+            override fun matches(path: String): Boolean = matcher.matches(path)
+        }
+
+        companion object {
+            operator fun invoke(rule: SensitiveFieldRule): CompiledRule {
+                val matcher = globToRegex(rule.fieldPattern)
+                return when (rule.action) {
+                    SensitiveFieldAction.ALLOW -> Allow(matcher)
+                    SensitiveFieldAction.MASK -> Mask(matcher, rule.replacement)
+                    SensitiveFieldAction.REMOVE -> Remove(matcher)
+                }
+            }
+
+            private fun globToRegex(pattern: String): Regex {
+                val normalized = pattern.trim().lowercase()
+                val regex = buildString {
+                    append('^')
+                    normalized.forEach { ch ->
+                        when (ch) {
+                            '*' -> append(".*")
+                            '.',
+                            '(',
+                            ')',
+                            '[',
+                            ']',
+                            '{',
+                            '}',
+                            '+',
+                            '?',
+                            '^',
+                            '$',
+                            '|',
+                            '\\',
+                            -> append('\\').append(ch)
+                            else -> append(ch)
+                        }
+                    }
+                    append('$')
+                }
+                return Regex(regex)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/github/aeshen/observability/ObservabilityFactoryTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/ObservabilityFactoryTest.kt
@@ -6,6 +6,8 @@ import io.github.aeshen.observability.codec.ObservabilityCodec
 import io.github.aeshen.observability.config.sink.OpenTelemetry
 import io.github.aeshen.observability.config.sink.SinkConfig
 import io.github.aeshen.observability.key.StringKey
+import io.github.aeshen.observability.processor.builtin.SensitiveFieldProcessor
+import io.github.aeshen.observability.processor.builtin.SensitiveFieldRule
 import io.github.aeshen.observability.sink.ObservabilitySink
 import io.github.aeshen.observability.sink.registry.SinkRegistry
 import java.net.InetSocketAddress
@@ -105,11 +107,15 @@ class ObservabilityFactoryTest {
     }
 
     @Test
-    fun `factory supports direct sink instance list`() {
+    fun `factory supports runtime sink instance via registry adapter`() {
         val seen = mutableListOf<EncodedEvent>()
+        val registry = directSinkRegistry()
         val observability =
             ObservabilityFactory.create(
-                CapturingSink(seen),
+                ObservabilityFactory.Config(
+                    sinks = listOf(DirectSinkConfig(CapturingSink(seen))),
+                    sinkRegistry = registry,
+                ),
             )
 
         observability.use {
@@ -126,16 +132,21 @@ class ObservabilityFactoryTest {
     @Test
     fun `factory accepts custom codec`() {
         val seen = mutableListOf<EncodedEvent>()
+        val customCodec =
+            ObservabilityCodec { event ->
+                EncodedEvent(
+                    original = event,
+                    encoded = "custom".toByteArray(Charsets.UTF_8),
+                )
+            }
+        val registry = directSinkRegistry()
         val observability =
             ObservabilityFactory.create(
-                CapturingSink(seen),
-                codec =
-                ObservabilityCodec { event ->
-                    EncodedEvent(
-                        original = event,
-                        encoded = "custom".toByteArray(Charsets.UTF_8),
-                    )
-                },
+                ObservabilityFactory.Config(
+                    sinks = listOf(DirectSinkConfig(CapturingSink(seen))),
+                    sinkRegistry = registry,
+                    codec = customCodec,
+                ),
             )
 
         observability.use {
@@ -240,17 +251,70 @@ class ObservabilityFactoryTest {
     }
 
     @Test
+    fun `factory config accepts custom processors`() {
+        val seen = mutableListOf<EncodedEvent>()
+        val passwordKey =
+            object : io.github.aeshen.observability.key.TypedKey<String> {
+                override val keyName: String = "password"
+            }
+        val processor =
+            SensitiveFieldProcessor(
+                rules = listOf(SensitiveFieldRule.remove("context.password")),
+            )
+        val registry =
+            SinkRegistry
+                .builder()
+                .register<ThirdPartySinkConfig> { CapturingSink(seen) }
+                .build()
+
+        val observability =
+            ObservabilityFactory.create(
+                ObservabilityFactory.Config(
+                    sinks = listOf(ThirdPartySinkConfig("partner-processor")),
+                    sinkRegistry = registry,
+                    processors = listOf(processor),
+                ),
+            )
+
+        val context =
+            ObservabilityContext
+                .builder()
+                .put(passwordKey, "secret")
+                .build()
+
+        observability.use {
+            it.info(
+                name = TestEvent.TEST,
+                message = "processor via config",
+                context = context,
+            )
+        }
+
+        val encoded = seen.single().encoded.toString(Charsets.UTF_8)
+        assertTrue(encoded.contains("processor via config"))
+        assertTrue(encoded.contains("\"context\":{}"))
+        assertTrue(encoded.contains("\"payloadPresent\":false"))
+        assertTrue(encoded.contains("\"payloadBase64\":\"\""))
+        assertTrue(encoded.contains("\"message\":\"processor via config\""))
+        assertTrue(!encoded.contains("secret"))
+    }
+
+    @Test
     fun `audit durable profile enforces strict sink failures`() {
         val failing =
             object : ObservabilitySink {
                 override fun handle(event: EncodedEvent) = error("always fails")
             }
+        val registry = directSinkRegistry()
 
         val observability =
             ObservabilityFactory.create(
-                failing,
-                failOnSinkError = false,
-                profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
+                ObservabilityFactory.Config(
+                    sinks = listOf(DirectSinkConfig(failing)),
+                    sinkRegistry = registry,
+                    failOnSinkError = false,
+                    profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
+                ),
             )
 
         assertFailsWith<IllegalStateException> {
@@ -274,11 +338,15 @@ class ObservabilityFactoryTest {
                     }
                 }
             }
+        val registry = directSinkRegistry()
 
         val observability =
             ObservabilityFactory.create(
-                flaky,
-                profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
+                ObservabilityFactory.Config(
+                    sinks = listOf(DirectSinkConfig(flaky)),
+                    sinkRegistry = registry,
+                    profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
+                ),
             )
 
         observability.use {
@@ -361,12 +429,16 @@ class ObservabilityFactoryTest {
             object : ObservabilitySink {
                 override fun handle(event: EncodedEvent) = error("always fail")
             }
+        val registry = directSinkRegistry()
 
         val observability =
             ObservabilityFactory.create(
-                failing,
-                profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
-                diagnostics = diagnostics,
+                ObservabilityFactory.Config(
+                    sinks = listOf(DirectSinkConfig(failing)),
+                    sinkRegistry = registry,
+                    profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
+                    diagnostics = diagnostics,
+                ),
             )
 
         assertFailsWith<IllegalStateException> {
@@ -394,6 +466,16 @@ class ObservabilityFactoryTest {
     private data class ThirdPartySinkConfig(
         val target: String,
     ) : SinkConfig
+
+    private data class DirectSinkConfig(
+        val sink: ObservabilitySink,
+    ) : SinkConfig
+
+    private fun directSinkRegistry(): SinkRegistry =
+        SinkRegistry
+            .builder()
+            .register<DirectSinkConfig> { config -> config.sink }
+            .build()
 
     private class CapturingSink(
         private val seen: MutableList<EncodedEvent>,

--- a/src/test/kotlin/io/github/aeshen/observability/processor/builtin/SensitiveFieldProcessorTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/processor/builtin/SensitiveFieldProcessorTest.kt
@@ -1,0 +1,271 @@
+package io.github.aeshen.observability.processor.builtin
+
+import io.github.aeshen.observability.EventName
+import io.github.aeshen.observability.ObservabilityContext
+import io.github.aeshen.observability.ObservabilityFactory
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.codec.ObservabilityCodec
+import io.github.aeshen.observability.config.sink.SinkConfig
+import io.github.aeshen.observability.enricher.MetadataEnricher
+import io.github.aeshen.observability.event
+import io.github.aeshen.observability.key.TypedKey
+import io.github.aeshen.observability.processor.ObservabilityProcessor
+import io.github.aeshen.observability.sink.EventLevel
+import io.github.aeshen.observability.sink.ObservabilitySink
+import io.github.aeshen.observability.sink.registry.SinkRegistry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SensitiveFieldProcessorTest {
+    private enum class TestEvent(
+        override val eventName: String? = null,
+    ) : EventName {
+        LOGIN("auth.login"),
+    }
+
+    private val passwordKey = textKey("password")
+    private val emailKey = textKey("email")
+    private val requestIdKey = textKey("requestId")
+    private val apiTokenKey = textKey("apiToken")
+    private val accessTokenKey = textKey("accessToken")
+
+    @Test
+    fun `processor masks and removes configured fields for default jsonl`() {
+        val sink = CapturingSink()
+        val rules =
+            listOf(
+                SensitiveFieldRule.allow("context.requestId"),
+                SensitiveFieldRule.remove("context.password"),
+                SensitiveFieldRule.mask("context.email", "[EMAIL]"),
+                SensitiveFieldRule.mask("metadata.apiToken", "[TOKEN]"),
+                SensitiveFieldRule.mask("message", "[MESSAGE]"),
+                SensitiveFieldRule.remove("payload"),
+            )
+        val processor =
+            SensitiveFieldProcessor(
+                rules = rules,
+            )
+        val enrichers =
+            listOf(
+                MetadataEnricher { encoded ->
+                    encoded.metadata["apiToken"] = "meta-secret"
+                    encoded.metadata["requestId"] = "meta-req"
+                },
+            )
+        val observability =
+            ObservabilityFactory.create(
+                ObservabilityFactory.Config(
+                    sinks = listOf(DirectSinkConfig(sink)),
+                    sinkRegistry = directSinkRegistry(),
+                    processors = listOf(processor),
+                    metadataEnrichers = enrichers,
+                ),
+            )
+
+        observability.use {
+            it.emit(
+                event(TestEvent.LOGIN) {
+                    level(EventLevel.INFO)
+                    message("customer email is jane@example.com")
+                    payload("raw-secret-payload".toByteArray(Charsets.UTF_8))
+                    context(passwordKey, "hunter2")
+                    context(emailKey, "jane@example.com")
+                    context(requestIdKey, "req-123")
+                },
+            )
+        }
+
+        val delivered = sink.events.single()
+        val encodedText = delivered.encoded.toString(Charsets.UTF_8)
+
+        assertNull(delivered.original.context.get(passwordKey))
+        assertEquals("[EMAIL]", delivered.original.context.get(emailKey))
+        assertEquals("req-123", delivered.original.context.get(requestIdKey))
+        assertEquals("[MESSAGE]", delivered.original.message)
+        assertNull(delivered.original.payload)
+
+        assertEquals("[TOKEN]", delivered.metadata["apiToken"])
+        assertEquals("meta-req", delivered.metadata["requestId"])
+
+        assertTrue(encodedText.contains("\"message\":\"[MESSAGE]\""))
+        assertTrue(encodedText.contains("\"email\":\"[EMAIL]\""))
+        assertTrue(encodedText.contains("\"payloadPresent\":false"))
+        assertFalse(encodedText.contains("hunter2"))
+        assertFalse(encodedText.contains("jane@example.com"))
+        assertFalse(encodedText.contains("raw-secret-payload"))
+    }
+
+    @Test
+    fun `explicit allow rules win over preset secret masks`() {
+        val sink = CapturingSink()
+        val processor =
+            SensitiveFieldProcessor(
+                rules = listOf(SensitiveFieldRule.allow("context.apiToken")),
+                presets = SensitiveFieldPresets.commonSecrets(mask = "[MASKED]"),
+            )
+        val observability =
+            ObservabilityFactory.create(
+                ObservabilityFactory.Config(
+                    sinks = listOf(DirectSinkConfig(sink)),
+                    sinkRegistry = directSinkRegistry(),
+                    processors = listOf(processor),
+                ),
+            )
+
+        val context =
+            ObservabilityContext
+                .builder()
+                .put(apiTokenKey, "keep-visible")
+                .put(accessTokenKey, "hide-me")
+                .build()
+
+        observability.use {
+            it.info(
+                name = TestEvent.LOGIN,
+                message = "preset coverage",
+                context = context,
+            )
+        }
+
+        val delivered = sink.events.single()
+        val encodedText = delivered.encoded.toString(Charsets.UTF_8)
+
+        assertEquals("keep-visible", delivered.original.context.get(apiTokenKey))
+        assertEquals("[MASKED]", delivered.original.context.get(accessTokenKey))
+        assertTrue(encodedText.contains("keep-visible"))
+        assertTrue(encodedText.contains("[MASKED]"))
+        assertFalse(encodedText.contains("hide-me"))
+    }
+
+    @Test
+    fun `processor sanitizes json based custom codecs where applicable`() {
+        val sink = CapturingSink()
+        val encodedJson =
+            """
+            {"message":"codec-secret","context":{"password":"json-password"},"metadata":{"sessionToken":"json-token"},"payload":"json-payload"}
+            """
+                .trimIndent()
+        val customCodec =
+            ObservabilityCodec { event ->
+                EncodedEvent(
+                    original = event,
+                    encoded = encodedJson.toByteArray(Charsets.UTF_8),
+                )
+            }
+        val rules =
+            listOf(
+                SensitiveFieldRule.mask("message", "[CODEC]"),
+                SensitiveFieldRule.remove("context.password"),
+                SensitiveFieldRule.mask("metadata.sessionToken", "[SESSION]"),
+                SensitiveFieldRule.remove("payload"),
+            )
+        val processor =
+            SensitiveFieldProcessor(
+                rules = rules,
+            )
+
+        val observability =
+            ObservabilityFactory.create(
+                ObservabilityFactory.Config(
+                    sinks = listOf(DirectSinkConfig(sink)),
+                    sinkRegistry = directSinkRegistry(),
+                    processors = listOf(processor),
+                    codec = customCodec,
+                ),
+            )
+
+        val eventContext =
+            ObservabilityContext
+                .builder()
+                .put(passwordKey, "event-password")
+                .build()
+
+        observability.use {
+            it.info(
+                name = TestEvent.LOGIN,
+                message = "event-message",
+                context = eventContext,
+            )
+        }
+
+        val encodedText = sink.events.single().encoded.toString(Charsets.UTF_8)
+        assertTrue(encodedText.contains("\"message\":\"[CODEC]\""))
+        assertTrue(encodedText.contains("\"sessionToken\":\"[SESSION]\""))
+        assertFalse(encodedText.contains("json-password"))
+        assertFalse(encodedText.contains("json-token"))
+        assertFalse(encodedText.contains("json-payload"))
+    }
+
+    @Test
+    fun `factory runs custom processors before encryption`() {
+        val sink = CapturingSink()
+        val checks = mutableListOf<String>()
+        val processor =
+            object : ObservabilityProcessor {
+                override fun process(event: EncodedEvent): EncodedEvent {
+                    val plaintext = event.encoded.toString(Charsets.UTF_8)
+                    val metadata = event.metadata.toMutableMap()
+                    checks += plaintext
+                    check(plaintext.contains("processor-order-secret")) {
+                        "Custom processors must see plaintext before encryption."
+                    }
+                    metadata["processorChecked"] = true
+                    return event.copy(metadata = metadata)
+                }
+            }
+        val observability =
+            ObservabilityFactory.create(
+                ObservabilityFactory.Config(
+                    sinks = listOf(DirectSinkConfig(sink)),
+                    sinkRegistry = directSinkRegistry(),
+                    processors = listOf(processor),
+                    encryption = ObservabilityFactory.Config.aesGcmFromRawKeyBytes(ByteArray(32) { 7 }),
+                ),
+            )
+
+        observability.use {
+            it.info(
+                name = TestEvent.LOGIN,
+                message = "processor-order-secret",
+            )
+        }
+
+        val delivered = sink.events.single()
+        val encodedText = delivered.encoded.toString(Charsets.UTF_8)
+
+        assertEquals(1, checks.size)
+        assertEquals(true, delivered.metadata["processorChecked"])
+        assertTrue(encodedText.contains("\"ciphertext\":\""))
+        assertFalse(encodedText.contains("processor-order-secret"))
+    }
+
+    private fun textKey(name: String): TypedKey<String> =
+        object : TypedKey<String> {
+            override val keyName: String = name
+        }
+
+    private data class DirectSinkConfig(
+        val sink: ObservabilitySink,
+    ) : SinkConfig
+
+    private fun directSinkRegistry(): SinkRegistry =
+        SinkRegistry
+            .builder()
+            .register<DirectSinkConfig> { config -> config.sink }
+            .build()
+
+    private class CapturingSink : ObservabilitySink {
+        val events = mutableListOf<EncodedEvent>()
+
+        override fun handle(event: EncodedEvent) {
+            events +=
+                event.copy(
+                    encoded = event.encoded.copyOf(),
+                    metadata = LinkedHashMap(event.metadata),
+                )
+        }
+    }
+}

--- a/src/test/kotlin/io/github/aeshen/observability/sink/testing/AdvancedConformanceTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/sink/testing/AdvancedConformanceTest.kt
@@ -3,7 +3,9 @@ package io.github.aeshen.observability.sink.testing
 import io.github.aeshen.observability.EventName
 import io.github.aeshen.observability.ObservabilityFactory
 import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.config.sink.SinkConfig
 import io.github.aeshen.observability.sink.ObservabilitySink
+import io.github.aeshen.observability.sink.registry.SinkRegistry
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -18,8 +20,11 @@ class AdvancedConformanceTest {
     fun `pipeline failOnSinkError true propagates sink handle failures`() {
         val obs =
             ObservabilityFactory.create(
-                FailingSink(),
-                failOnSinkError = true,
+                ObservabilityFactory.Config(
+                    sinks = listOf(DirectSinkConfig(FailingSink())),
+                    sinkRegistry = directSinkRegistry(),
+                    failOnSinkError = true,
+                ),
             )
 
         assertFailsWith<IllegalStateException> {
@@ -36,8 +41,11 @@ class AdvancedConformanceTest {
     fun `pipeline failOnSinkError false swallows sink handle failures`() {
         val obs =
             ObservabilityFactory.create(
-                FailingSink(),
-                failOnSinkError = false,
+                ObservabilityFactory.Config(
+                    sinks = listOf(DirectSinkConfig(FailingSink())),
+                    sinkRegistry = directSinkRegistry(),
+                    failOnSinkError = false,
+                ),
             )
 
         obs.use {
@@ -53,4 +61,14 @@ class AdvancedConformanceTest {
             error("sink failure")
         }
     }
+
+    private data class DirectSinkConfig(
+        val sink: ObservabilitySink,
+    ) : SinkConfig
+
+    private fun directSinkRegistry(): SinkRegistry =
+        SinkRegistry
+            .builder()
+            .register<DirectSinkConfig> { config -> config.sink }
+            .build()
 }


### PR DESCRIPTION
Introduce first-party sensitive-field processing to sanitize events before sink delivery.

## What changed
- add `SensitiveFieldProcessor` with deterministic first-match rule evaluation (`ALLOW`, `MASK`, `REMOVE`) and glob-based field matching
- add `SensitiveFieldPresets.commonSecrets()` for common secret/token/email patterns
- sanitize `EncodedEvent.original`, `EncodedEvent.metadata`, and JSON encoded payloads (default JSONL + JSON-based custom codecs where applicable)
- add `processors` support on `ObservabilityFactory.Config` and ensure custom processors run before encryption processors
- keep legacy `ObservabilityFactory.create(vararg sinks, ...)` as deprecated compatibility bridge delegating to `create(config: Config)` via registry adapter
- align sink wiring guidance toward `Config.sinks` + `SinkRegistry`
- add/adjust tests for processor behavior, ordering, factory integration, and conformance usage
- update `README.md`, `docs/extensions.md`, `docs/spi-contract.md`, `CHANGELOG.md`, and refresh `api/observability.api`

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [x] Sinks / sink decorators
- [x] Codec / processors / encryption
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [ ] Docs

## Validation

- [x] Added/updated tests
- [x] Ran `./gradlew test`
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew detekt`
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [x] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] `AUDIT_DURABLE` behavior reviewed when reliability logic changed

## Docs & release notes

- [x] Updated `README.md`/docs where user-visible behavior changed
- [x] Updated `CHANGELOG.md` (if needed)
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
