### PR TITLE
feat(query-spi): add cursor-based pagination support (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and the project follows Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+- **Cursor-based pagination** in `query-spi` (issue #9):
+  - New `AuditPagination` sealed type with two subtypes:
+    - `AuditPagination.Offset(limit, offset)` — traditional limit/offset pagination, equivalent to the existing `AuditPage` semantics.
+    - `AuditPagination.Cursor(after, limit)` — cursor-based (keyset) pagination for large datasets and real-time feeds, avoiding row-shift inconsistency.
+  - `AuditSearchQuery.pagination: AuditPagination?` — new optional field that takes precedence over the deprecated `page` field when set.
+  - `AuditSearchQuery.resolvedPagination: AuditPagination` — computed property returning the effective pagination strategy regardless of which field was set.
+  - `AuditSearchQuery.Builder` — fluent Java-friendly builder (`AuditSearchQuery.builder(from, to).pagination(...).build()`).
+  - `AuditQueryResult.nextCursor: String?` — opaque continuation token returned by cursor-capable backends; `null` when there are no more results or the backend does not support cursors.
+  - `TranslatedAuditQuery.pagination: AuditPagination` replaces `page: AuditPage` in the reference translator kit output.
+  - `ReferenceBackendQuery.cursorAfter: String?` — non-null when cursor pagination is active; `offset` is set to `0` in that case.
+
+### Deprecated
+- `AuditPage` — use `AuditPagination.Offset` instead.
+- `AuditSearchQuery.page` — use `AuditSearchQuery.pagination` or `resolvedPagination` instead.
+- `TranslatedAuditQuery.page` — use `TranslatedAuditQuery.pagination` instead.
+
+### Breaking changes (`query-spi`)
+These are binary-incompatible changes inherent to evolving Kotlin data classes. Source-level
+compatibility is preserved for all existing call sites that use named parameters or omit trailing
+default arguments. Any module compiled against the previous `query-spi` artifact must be
+recompiled.
+
+- **`AuditQueryResult`** — `copy()` signature changed from `copy(records, total)` to
+  `copy(records, total, nextCursor)`. The two-argument Java constructor `new AuditQueryResult(records, total)`
+  is preserved via `@JvmOverloads`, but compiled Kotlin call sites that used `.copy(...)` must be
+  recompiled.
+- **`AuditSearchQuery`** — primary constructor gains a trailing `pagination: AuditPagination?`
+  parameter. The Kotlin synthetic default constructor changes accordingly. Existing Kotlin source
+  code (`AuditSearchQuery(from, to)`, `AuditSearchQuery(from, to, criteria = ...)`) recompiles
+  without modification, but code compiled against the previous binary must be recompiled.
+- **`TranslatedAuditQuery`** — the `page: AuditPage` constructor parameter is replaced by
+  `pagination: AuditPagination`. Code that constructed `TranslatedAuditQuery` directly
+  (uncommon — the type is normally produced by `AuditSearchQueryTranslator`) must be updated.
+  A backward-compatible `page` accessor is provided as a deprecated computed property.
+
 ## [1.2.0] - Unreleased
 
 ### Added

--- a/query-spi/README.md
+++ b/query-spi/README.md
@@ -92,6 +92,51 @@ fun toBackendQuery(query: AuditSearchQuery): String {
 For a full reference translation demo (criteria groups, text semantics, sort mapping, paging), see:
 `io.github.aeshen.observability.query.reference.demo.ReferenceBackendTranslator`.
 
+## Cursor-based pagination
+
+By default `AuditSearchQuery` uses offset pagination via the `AuditPage` type. For large datasets
+or real-time feeds, cursor-based pagination avoids the row-shift problem and is more efficient on
+most backends.
+
+Use `AuditPagination.Cursor` to opt in:
+
+```kotlin
+// First page — no cursor yet
+val firstPage = AuditSearchQuery(
+    fromEpochMillis = 1_710_000_000_000,
+    toEpochMillis   = 1_710_003_600_000,
+    pagination      = AuditPagination.Offset(limit = 50),
+    sort            = listOf(
+        AuditSort(AuditField.TIMESTAMP_EPOCH_MILLIS, AuditSortDirection.DESC),
+        AuditSort(AuditField.ID, AuditSortDirection.ASC),  // tiebreaker — required for cursor stability
+    ),
+)
+val result1: AuditQueryResult = service.search(firstPage)
+
+// Subsequent pages — pass nextCursor from the previous result
+result1.nextCursor?.let { cursor ->
+    val nextPage = AuditSearchQuery(
+        fromEpochMillis = 1_710_000_000_000,
+        toEpochMillis   = 1_710_003_600_000,
+        pagination      = AuditPagination.Cursor(limit = 50, after = cursor),
+        sort            = firstPage.sort,
+    )
+    val result2: AuditQueryResult = service.search(nextPage)
+}
+```
+
+`AuditQueryResult.nextCursor` is `null` when there are no more results or when the backend does
+not support cursor pagination.
+
+**Stable sort requirement:** cursor pagination depends on a deterministic result order. Always
+include a tie-breaking field such as `AuditField.ID` as the last sort clause. Backends may reject
+or silently fall back to offset pagination if no stable sort is present.
+
+**Backend authors:** backends that support cursor pagination should populate
+`AuditQueryResult.nextCursor` with an opaque token (e.g. base64-encoded keyset values,
+Elasticsearch `search_after` payload) and handle `AuditPagination.Cursor.after` in queries.
+Backends that do not support cursors may ignore the `after` field and leave `nextCursor` as `null`.
+
 ## Query semantics guidance
 
 Recommended semantics for portable behavior across backends:

--- a/query-spi/api/query-spi.api
+++ b/query-spi/api/query-spi.api
@@ -108,6 +108,41 @@ public final class io/github/aeshen/observability/query/AuditPage {
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class io/github/aeshen/observability/query/AuditPagination {
+	public abstract fun getLimit ()I
+}
+
+public final class io/github/aeshen/observability/query/AuditPagination$Cursor : io/github/aeshen/observability/query/AuditPagination {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;I)V
+	public synthetic fun <init> (Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Lio/github/aeshen/observability/query/AuditPagination$Cursor;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/AuditPagination$Cursor;Ljava/lang/String;IILjava/lang/Object;)Lio/github/aeshen/observability/query/AuditPagination$Cursor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAfter ()Ljava/lang/String;
+	public fun getLimit ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/aeshen/observability/query/AuditPagination$Offset : io/github/aeshen/observability/query/AuditPagination {
+	public fun <init> ()V
+	public fun <init> (I)V
+	public fun <init> (II)V
+	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lio/github/aeshen/observability/query/AuditPagination$Offset;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/AuditPagination$Offset;IIILjava/lang/Object;)Lio/github/aeshen/observability/query/AuditPagination$Offset;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLimit ()I
+	public final fun getOffset ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/aeshen/observability/query/AuditQuery {
 	public fun <init> (JJIILjava/util/Map;Ljava/lang/String;)V
 	public synthetic fun <init> (JJIILjava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -133,11 +168,15 @@ public final class io/github/aeshen/observability/query/AuditQuery {
 
 public final class io/github/aeshen/observability/query/AuditQueryResult {
 	public fun <init> (Ljava/util/List;J)V
+	public fun <init> (Ljava/util/List;JLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()J
-	public final fun copy (Ljava/util/List;J)Lio/github/aeshen/observability/query/AuditQueryResult;
-	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/AuditQueryResult;Ljava/util/List;JILjava/lang/Object;)Lio/github/aeshen/observability/query/AuditQueryResult;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;JLjava/lang/String;)Lio/github/aeshen/observability/query/AuditQueryResult;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/AuditQueryResult;Ljava/util/List;JLjava/lang/String;ILjava/lang/Object;)Lio/github/aeshen/observability/query/AuditQueryResult;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNextCursor ()Ljava/lang/String;
 	public final fun getRecords ()Ljava/util/List;
 	public final fun getTotal ()J
 	public fun hashCode ()I
@@ -177,25 +216,43 @@ public final class io/github/aeshen/observability/query/AuditRecord {
 }
 
 public final class io/github/aeshen/observability/query/AuditSearchQuery {
-	public fun <init> (JJLio/github/aeshen/observability/query/AuditPage;Ljava/util/List;Lio/github/aeshen/observability/query/AuditTextQuery;Ljava/util/List;)V
-	public synthetic fun <init> (JJLio/github/aeshen/observability/query/AuditPage;Ljava/util/List;Lio/github/aeshen/observability/query/AuditTextQuery;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final field Companion Lio/github/aeshen/observability/query/AuditSearchQuery$Companion;
+	public fun <init> (JJLio/github/aeshen/observability/query/AuditPage;Ljava/util/List;Lio/github/aeshen/observability/query/AuditTextQuery;Ljava/util/List;Lio/github/aeshen/observability/query/AuditPagination;)V
+	public synthetic fun <init> (JJLio/github/aeshen/observability/query/AuditPage;Ljava/util/List;Lio/github/aeshen/observability/query/AuditTextQuery;Ljava/util/List;Lio/github/aeshen/observability/query/AuditPagination;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun builder (JJ)Lio/github/aeshen/observability/query/AuditSearchQuery$Builder;
 	public final fun component1 ()J
 	public final fun component2 ()J
 	public final fun component3 ()Lio/github/aeshen/observability/query/AuditPage;
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Lio/github/aeshen/observability/query/AuditTextQuery;
 	public final fun component6 ()Ljava/util/List;
-	public final fun copy (JJLio/github/aeshen/observability/query/AuditPage;Ljava/util/List;Lio/github/aeshen/observability/query/AuditTextQuery;Ljava/util/List;)Lio/github/aeshen/observability/query/AuditSearchQuery;
-	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/AuditSearchQuery;JJLio/github/aeshen/observability/query/AuditPage;Ljava/util/List;Lio/github/aeshen/observability/query/AuditTextQuery;Ljava/util/List;ILjava/lang/Object;)Lio/github/aeshen/observability/query/AuditSearchQuery;
+	public final fun component7 ()Lio/github/aeshen/observability/query/AuditPagination;
+	public final fun copy (JJLio/github/aeshen/observability/query/AuditPage;Ljava/util/List;Lio/github/aeshen/observability/query/AuditTextQuery;Ljava/util/List;Lio/github/aeshen/observability/query/AuditPagination;)Lio/github/aeshen/observability/query/AuditSearchQuery;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/AuditSearchQuery;JJLio/github/aeshen/observability/query/AuditPage;Ljava/util/List;Lio/github/aeshen/observability/query/AuditTextQuery;Ljava/util/List;Lio/github/aeshen/observability/query/AuditPagination;ILjava/lang/Object;)Lio/github/aeshen/observability/query/AuditSearchQuery;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCriteria ()Ljava/util/List;
 	public final fun getFromEpochMillis ()J
 	public final fun getPage ()Lio/github/aeshen/observability/query/AuditPage;
+	public final fun getPagination ()Lio/github/aeshen/observability/query/AuditPagination;
+	public final fun getResolvedPagination ()Lio/github/aeshen/observability/query/AuditPagination;
 	public final fun getSort ()Ljava/util/List;
 	public final fun getText ()Lio/github/aeshen/observability/query/AuditTextQuery;
 	public final fun getToEpochMillis ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/aeshen/observability/query/AuditSearchQuery$Builder {
+	public fun <init> (JJ)V
+	public final fun build ()Lio/github/aeshen/observability/query/AuditSearchQuery;
+	public final fun criteria (Ljava/util/List;)Lio/github/aeshen/observability/query/AuditSearchQuery$Builder;
+	public final fun pagination (Lio/github/aeshen/observability/query/AuditPagination;)Lio/github/aeshen/observability/query/AuditSearchQuery$Builder;
+	public final fun sort (Ljava/util/List;)Lio/github/aeshen/observability/query/AuditSearchQuery$Builder;
+	public final fun text (Lio/github/aeshen/observability/query/AuditTextQuery;)Lio/github/aeshen/observability/query/AuditSearchQuery$Builder;
+}
+
+public final class io/github/aeshen/observability/query/AuditSearchQuery$Companion {
+	public final fun builder (JJ)Lio/github/aeshen/observability/query/AuditSearchQuery$Builder;
 }
 
 public abstract interface class io/github/aeshen/observability/query/AuditSearchQueryService {
@@ -417,19 +474,20 @@ public final class io/github/aeshen/observability/query/reference/StandardAuditF
 }
 
 public final class io/github/aeshen/observability/query/reference/TranslatedAuditQuery {
-	public fun <init> (JJLjava/lang/Object;Ljava/lang/Object;Ljava/util/List;Lio/github/aeshen/observability/query/AuditPage;)V
+	public fun <init> (JJLjava/lang/Object;Ljava/lang/Object;Ljava/util/List;Lio/github/aeshen/observability/query/AuditPagination;)V
 	public final fun component1 ()J
 	public final fun component2 ()J
 	public final fun component3 ()Ljava/lang/Object;
 	public final fun component4 ()Ljava/lang/Object;
 	public final fun component5 ()Ljava/util/List;
-	public final fun component6 ()Lio/github/aeshen/observability/query/AuditPage;
-	public final fun copy (JJLjava/lang/Object;Ljava/lang/Object;Ljava/util/List;Lio/github/aeshen/observability/query/AuditPage;)Lio/github/aeshen/observability/query/reference/TranslatedAuditQuery;
-	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/reference/TranslatedAuditQuery;JJLjava/lang/Object;Ljava/lang/Object;Ljava/util/List;Lio/github/aeshen/observability/query/AuditPage;ILjava/lang/Object;)Lio/github/aeshen/observability/query/reference/TranslatedAuditQuery;
+	public final fun component6 ()Lio/github/aeshen/observability/query/AuditPagination;
+	public final fun copy (JJLjava/lang/Object;Ljava/lang/Object;Ljava/util/List;Lio/github/aeshen/observability/query/AuditPagination;)Lio/github/aeshen/observability/query/reference/TranslatedAuditQuery;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/reference/TranslatedAuditQuery;JJLjava/lang/Object;Ljava/lang/Object;Ljava/util/List;Lio/github/aeshen/observability/query/AuditPagination;ILjava/lang/Object;)Lio/github/aeshen/observability/query/reference/TranslatedAuditQuery;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFilter ()Ljava/lang/Object;
 	public final fun getFromEpochMillis ()J
 	public final fun getPage ()Lio/github/aeshen/observability/query/AuditPage;
+	public final fun getPagination ()Lio/github/aeshen/observability/query/AuditPagination;
 	public final fun getSort ()Ljava/util/List;
 	public final fun getText ()Ljava/lang/Object;
 	public final fun getToEpochMillis ()J
@@ -438,16 +496,19 @@ public final class io/github/aeshen/observability/query/reference/TranslatedAudi
 }
 
 public final class io/github/aeshen/observability/query/reference/demo/ReferenceBackendQuery {
-	public fun <init> (JJLjava/lang/String;Ljava/util/List;II)V
+	public fun <init> (JJLjava/lang/String;Ljava/util/List;IILjava/lang/String;)V
+	public synthetic fun <init> (JJLjava/lang/String;Ljava/util/List;IILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component2 ()J
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()I
 	public final fun component6 ()I
-	public final fun copy (JJLjava/lang/String;Ljava/util/List;II)Lio/github/aeshen/observability/query/reference/demo/ReferenceBackendQuery;
-	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/reference/demo/ReferenceBackendQuery;JJLjava/lang/String;Ljava/util/List;IIILjava/lang/Object;)Lio/github/aeshen/observability/query/reference/demo/ReferenceBackendQuery;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (JJLjava/lang/String;Ljava/util/List;IILjava/lang/String;)Lio/github/aeshen/observability/query/reference/demo/ReferenceBackendQuery;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/reference/demo/ReferenceBackendQuery;JJLjava/lang/String;Ljava/util/List;IILjava/lang/String;ILjava/lang/Object;)Lio/github/aeshen/observability/query/reference/demo/ReferenceBackendQuery;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursorAfter ()Ljava/lang/String;
 	public final fun getFromEpochMillis ()J
 	public final fun getLimit ()I
 	public final fun getOffset ()I

--- a/query-spi/src/main/kotlin/io/github/aeshen/observability/query/AuditPagination.kt
+++ b/query-spi/src/main/kotlin/io/github/aeshen/observability/query/AuditPagination.kt
@@ -1,0 +1,59 @@
+package io.github.aeshen.observability.query
+
+/**
+ * Pagination strategy for [AuditSearchQuery].
+ *
+ * Use [Offset] for traditional limit/offset pagination.
+ * Use [Cursor] for cursor-based (keyset) pagination when the backend supports it.
+ *
+ * Backends that return a cursor will populate [io.github.aeshen.observability.query.AuditQueryResult.nextCursor].
+ * Pass that value as [Cursor.after] in the next request to retrieve the following page.
+ *
+ * **Note on stable sort:** cursor pagination requires a deterministic sort order. Ensure the
+ * [AuditSearchQuery.sort] list includes at least one tie-breaking field (e.g. [AuditField.ID]
+ * or [AuditField.TIMESTAMP_EPOCH_MILLIS]) to guarantee consistent page boundaries across requests.
+ */
+sealed interface AuditPagination {
+    /** Maximum number of records to return per page. Must be greater than 0. */
+    val limit: Int
+
+    /**
+     * Traditional offset-based pagination.
+     *
+     * @param limit Maximum records per page. Defaults to 100.
+     * @param offset Number of records to skip. Defaults to 0.
+     */
+    data class Offset
+        @JvmOverloads
+        constructor(
+            override val limit: Int = 100,
+            val offset: Int = 0,
+        ) : AuditPagination {
+            init {
+                require(limit > 0) { "limit must be greater than 0." }
+                require(offset >= 0) { "offset must be greater than or equal to 0." }
+            }
+        }
+
+    /**
+     * Cursor-based (keyset) pagination.
+     *
+     * The [after] token is an opaque, backend-specific continuation marker returned in
+     * [io.github.aeshen.observability.query.AuditQueryResult.nextCursor].
+     * Pass it unchanged in the next request.
+     *
+     * @param after Opaque continuation token from the previous page's [AuditQueryResult.nextCursor].
+     * @param limit Maximum records per page. Defaults to 100.
+     */
+    data class Cursor
+        @JvmOverloads
+        constructor(
+            val after: String,
+            override val limit: Int = 100,
+        ) : AuditPagination {
+            init {
+                require(limit > 0) { "limit must be greater than 0." }
+                require(after.isNotBlank()) { "after cursor must not be blank." }
+            }
+        }
+}

--- a/query-spi/src/main/kotlin/io/github/aeshen/observability/query/AuditQueryResult.kt
+++ b/query-spi/src/main/kotlin/io/github/aeshen/observability/query/AuditQueryResult.kt
@@ -1,11 +1,24 @@
 package io.github.aeshen.observability.query
 
-data class AuditQueryResult(
-    val records: List<AuditRecord>,
-    val total: Long,
-) {
-    init {
-        require(total >= 0) { "total must be greater than or equal to 0." }
-        require(total >= records.size.toLong()) { "total must be greater than or equal to records.size." }
+/**
+ * Result of an [AuditSearchQueryService.search] call.
+ *
+ * @property records The records matching the query for the requested page.
+ * @property total Total number of matching records across all pages (best-effort; may be -1 if
+ *   the backend does not support exact counts).
+ * @property nextCursor Opaque continuation token for the next page, or `null` when there are no
+ *   more results or when the backend does not support cursor-based pagination. Pass this value as
+ *   [AuditPagination.Cursor.after] in the subsequent request.
+ */
+data class AuditQueryResult
+    @JvmOverloads
+    constructor(
+        val records: List<AuditRecord>,
+        val total: Long,
+        val nextCursor: String? = null,
+    ) {
+        init {
+            require(total >= 0) { "total must be greater than or equal to 0." }
+            require(total >= records.size.toLong()) { "total must be greater than or equal to records.size." }
+        }
     }
-}

--- a/query-spi/src/main/kotlin/io/github/aeshen/observability/query/AuditSearchQuery.kt
+++ b/query-spi/src/main/kotlin/io/github/aeshen/observability/query/AuditSearchQuery.kt
@@ -4,19 +4,82 @@ package io.github.aeshen.observability.query
 
 /**
  * Typed, backend-agnostic query contract intended for long-term API stability.
+ *
+ * Use [pagination] to control how results are paged. When [pagination] is non-null it takes
+ * precedence over the deprecated [page] field. Use [resolvedPagination] to obtain the effective
+ * pagination strategy regardless of which field was set.
  */
 data class AuditSearchQuery(
     val fromEpochMillis: Long,
     val toEpochMillis: Long,
+    @Deprecated(
+        message = "Use pagination instead.",
+        replaceWith = ReplaceWith("pagination"),
+    )
     val page: AuditPage = AuditPage(),
     val criteria: List<AuditCriterion> = emptyList(),
     val text: AuditTextQuery? = null,
     val sort: List<AuditSort> = listOf(AuditSort(field = AuditField.TIMESTAMP_EPOCH_MILLIS)),
+    val pagination: AuditPagination? = null,
 ) {
     init {
         require(fromEpochMillis >= 0) { "fromEpochMillis must be greater than or equal to 0." }
         require(toEpochMillis >= 0) { "toEpochMillis must be greater than or equal to 0." }
         require(fromEpochMillis <= toEpochMillis) { "fromEpochMillis must be less than or equal to toEpochMillis." }
+    }
+
+    /**
+     * The effective pagination strategy. When [pagination] is set it is returned directly;
+     * otherwise falls back to an [AuditPagination.Offset] derived from the deprecated [page] field.
+     */
+    val resolvedPagination: AuditPagination
+        get() = pagination ?: AuditPagination.Offset(limit = page.limit, offset = page.offset)
+
+    companion object {
+        /** Java-friendly entry point for the fluent builder. */
+        @JvmStatic
+        fun builder(
+            fromEpochMillis: Long,
+            toEpochMillis: Long,
+        ): Builder = Builder(fromEpochMillis, toEpochMillis)
+    }
+
+    /**
+     * Fluent builder for [AuditSearchQuery] intended for Java callers.
+     *
+     * ```java
+     * AuditSearchQuery query = AuditSearchQuery.builder(from, to)
+     *     .pagination(new AuditPagination.Cursor("eyJpZCI6Imxhc3QifQ=="))
+     *     .sort(List.of(new AuditSort(AuditField.ID, AuditSortDirection.ASC)))
+     *     .build();
+     * ```
+     */
+    class Builder(
+        private val fromEpochMillis: Long,
+        private val toEpochMillis: Long,
+    ) {
+        private var criteria: List<AuditCriterion> = emptyList()
+        private var text: AuditTextQuery? = null
+        private var sort: List<AuditSort> = listOf(AuditSort(field = AuditField.TIMESTAMP_EPOCH_MILLIS))
+        private var pagination: AuditPagination? = null
+
+        fun criteria(criteria: List<AuditCriterion>) = apply { this.criteria = criteria }
+
+        fun text(text: AuditTextQuery) = apply { this.text = text }
+
+        fun sort(sort: List<AuditSort>) = apply { this.sort = sort }
+
+        fun pagination(pagination: AuditPagination) = apply { this.pagination = pagination }
+
+        fun build(): AuditSearchQuery =
+            AuditSearchQuery(
+                fromEpochMillis = fromEpochMillis,
+                toEpochMillis = toEpochMillis,
+                criteria = criteria,
+                text = text,
+                sort = sort,
+                pagination = pagination,
+            )
     }
 }
 

--- a/query-spi/src/main/kotlin/io/github/aeshen/observability/query/reference/AuditSearchQueryTranslator.kt
+++ b/query-spi/src/main/kotlin/io/github/aeshen/observability/query/reference/AuditSearchQueryTranslator.kt
@@ -5,6 +5,7 @@ import io.github.aeshen.observability.query.AuditCriterion
 import io.github.aeshen.observability.query.AuditField
 import io.github.aeshen.observability.query.AuditLogicalOperator
 import io.github.aeshen.observability.query.AuditPage
+import io.github.aeshen.observability.query.AuditPagination
 import io.github.aeshen.observability.query.AuditSearchQuery
 import io.github.aeshen.observability.query.AuditSort
 import io.github.aeshen.observability.query.AuditSortDirection
@@ -13,6 +14,9 @@ import io.github.aeshen.observability.query.AuditValue
 
 /**
  * Backend-neutral translation output produced from an [AuditSearchQuery].
+ *
+ * The [pagination] field carries the resolved pagination strategy. The [page] property is kept
+ * for backward compatibility but is deprecated — prefer [pagination].
  */
 data class TranslatedAuditQuery<P, S, T>(
     val fromEpochMillis: Long,
@@ -20,8 +24,20 @@ data class TranslatedAuditQuery<P, S, T>(
     val filter: P?,
     val text: T?,
     val sort: List<S>,
-    val page: AuditPage,
-)
+    val pagination: AuditPagination,
+) {
+    /** Backward-compatible accessor derived from [pagination]. Prefer [pagination] for new code. */
+    @Deprecated(
+        message = "Use pagination instead.",
+        replaceWith = ReplaceWith("pagination"),
+    )
+    val page: AuditPage
+        get() =
+            when (val p = pagination) {
+                is AuditPagination.Offset -> AuditPage(limit = p.limit, offset = p.offset)
+                is AuditPagination.Cursor -> AuditPage(limit = p.limit, offset = 0)
+            }
+}
 
 /**
  * Maps [AuditField] values into backend-specific field identifiers.
@@ -88,7 +104,7 @@ class AuditSearchQueryTranslator<F, P, S, T>(
             filter = filter,
             text = text,
             sort = sort,
-            page = query.page,
+            pagination = query.resolvedPagination,
         )
     }
 

--- a/query-spi/src/main/kotlin/io/github/aeshen/observability/query/reference/demo/ReferenceBackendTranslator.kt
+++ b/query-spi/src/main/kotlin/io/github/aeshen/observability/query/reference/demo/ReferenceBackendTranslator.kt
@@ -2,6 +2,7 @@ package io.github.aeshen.observability.query.reference.demo
 
 import io.github.aeshen.observability.query.AuditComparisonOperator
 import io.github.aeshen.observability.query.AuditLogicalOperator
+import io.github.aeshen.observability.query.AuditPagination
 import io.github.aeshen.observability.query.AuditSearchQuery
 import io.github.aeshen.observability.query.AuditTextMatchMode
 import io.github.aeshen.observability.query.AuditValue
@@ -11,6 +12,10 @@ import io.github.aeshen.observability.query.reference.StandardAuditFieldMapper
 
 /**
  * Demonstrates one complete translation path from [AuditSearchQuery] to backend clauses.
+ *
+ * When cursor-based pagination is used (see [AuditPagination.Cursor]) the [ReferenceBackendQuery.cursorAfter]
+ * field is populated and [ReferenceBackendQuery.offset] is set to 0. Backends should use [cursorAfter]
+ * as their keyset / search_after value and ignore [offset] in that case.
  */
 data class ReferenceBackendQuery(
     val fromEpochMillis: Long,
@@ -19,6 +24,8 @@ data class ReferenceBackendQuery(
     val sortClauses: List<String>,
     val limit: Int,
     val offset: Int,
+    /** Non-null when the query used [AuditPagination.Cursor]; pass to the backend keyset mechanism. */
+    val cursorAfter: String? = null,
 )
 
 object ReferenceBackendTranslator {
@@ -43,13 +50,20 @@ object ReferenceBackendTranslator {
         val translated = translator.translate(query)
         val whereClause = combineWhereClauses(translated.filter, translated.text)
 
+        val (limit, offset, cursorAfter) =
+            when (val p = translated.pagination) {
+                is AuditPagination.Offset -> Triple(p.limit, p.offset, null)
+                is AuditPagination.Cursor -> Triple(p.limit, 0, p.after)
+            }
+
         return ReferenceBackendQuery(
             fromEpochMillis = translated.fromEpochMillis,
             toEpochMillis = translated.toEpochMillis,
             whereClause = whereClause,
             sortClauses = translated.sort,
-            limit = translated.page.limit,
-            offset = translated.page.offset,
+            limit = limit,
+            offset = offset,
+            cursorAfter = cursorAfter,
         )
     }
 

--- a/query-spi/src/test/kotlin/io/github/aeshen/observability/query/QueryModelValidationTest.kt
+++ b/query-spi/src/test/kotlin/io/github/aeshen/observability/query/QueryModelValidationTest.kt
@@ -79,7 +79,7 @@ class QueryModelValidationTest {
 
         assertEquals(10, typed.fromEpochMillis)
         assertEquals(20, typed.toEpochMillis)
-        assertEquals(AuditPage(limit = 25, offset = 5), typed.page)
+        assertEquals(AuditPagination.Offset(limit = 25, offset = 5), typed.resolvedPagination)
         assertEquals(
             listOf(
                 AuditCriterion.Comparison(
@@ -144,7 +144,7 @@ class QueryModelValidationTest {
         val service =
             object : AuditSearchQueryService {
                 override fun search(query: AuditSearchQuery): AuditQueryResult {
-                    assertEquals(AuditPage(limit = 7, offset = 3), query.page)
+                    assertEquals(AuditPagination.Offset(limit = 7, offset = 3), query.resolvedPagination)
                     assertEquals(AuditTextQuery("billing"), query.text)
                     return AuditQueryResult(records = emptyList(), total = 1)
                 }
@@ -221,7 +221,59 @@ class QueryModelValidationTest {
     }
 
     @Test
-    fun `audit query result validates total constraints`() {
+    fun `audit pagination offset validates constraints`() {
+        assertFailsWith<IllegalArgumentException> {
+            AuditPagination.Offset(limit = 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            AuditPagination.Offset(offset = -1)
+        }
+        val valid = AuditPagination.Offset(limit = 50, offset = 100)
+        assertEquals(50, valid.limit)
+        assertEquals(100, valid.offset)
+    }
+
+    @Test
+    fun `audit pagination cursor validates constraints`() {
+        assertFailsWith<IllegalArgumentException> {
+            AuditPagination.Cursor(limit = 0, after = "token")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            AuditPagination.Cursor(limit = 10, after = "   ")
+        }
+        val valid = AuditPagination.Cursor(limit = 25, after = "opaque-token-abc")
+        assertEquals(25, valid.limit)
+        assertEquals("opaque-token-abc", valid.after)
+    }
+
+    @Test
+    fun `audit search query resolved pagination falls back to page when pagination is null`() {
+        @Suppress("DEPRECATION")
+        val query =
+            AuditSearchQuery(
+                fromEpochMillis = 0,
+                toEpochMillis = 100,
+                page = AuditPage(limit = 30, offset = 60),
+            )
+        val resolved = query.resolvedPagination
+        assertEquals(AuditPagination.Offset(limit = 30, offset = 60), resolved)
+    }
+
+    @Test
+    fun `audit search query resolved pagination prefers pagination over page`() {
+        @Suppress("DEPRECATION")
+        val query =
+            AuditSearchQuery(
+                fromEpochMillis = 0,
+                toEpochMillis = 100,
+                page = AuditPage(limit = 30, offset = 60),
+                pagination = AuditPagination.Cursor(limit = 20, after = "my-cursor"),
+            )
+        assertEquals(AuditPagination.Cursor(limit = 20, after = "my-cursor"), query.resolvedPagination)
+    }
+
+    @Test
+    fun `audit query result stores next cursor`() {
         val record =
             AuditRecord(
                 id = "id-1",
@@ -231,12 +283,10 @@ class QueryModelValidationTest {
                 message = null,
                 context = emptyMap(),
             )
+        val withCursor = AuditQueryResult(records = listOf(record), total = 1, nextCursor = "eyJpZCI6Imxhc3QifQ==")
+        assertEquals("eyJpZCI6Imxhc3QifQ==", withCursor.nextCursor)
 
-        assertFailsWith<IllegalArgumentException> {
-            AuditQueryResult(records = listOf(record), total = -1)
-        }
-        assertFailsWith<IllegalArgumentException> {
-            AuditQueryResult(records = listOf(record), total = 0)
-        }
+        val withoutCursor = AuditQueryResult(records = listOf(record), total = 1)
+        assertEquals(null, withoutCursor.nextCursor)
     }
 }

--- a/query-spi/src/test/kotlin/io/github/aeshen/observability/query/reference/TranslatorKitTest.kt
+++ b/query-spi/src/test/kotlin/io/github/aeshen/observability/query/reference/TranslatorKitTest.kt
@@ -5,6 +5,7 @@ import io.github.aeshen.observability.query.AuditCriterion
 import io.github.aeshen.observability.query.AuditField
 import io.github.aeshen.observability.query.AuditLogicalOperator
 import io.github.aeshen.observability.query.AuditPage
+import io.github.aeshen.observability.query.AuditPagination
 import io.github.aeshen.observability.query.AuditSearchQuery
 import io.github.aeshen.observability.query.AuditSort
 import io.github.aeshen.observability.query.AuditSortDirection
@@ -16,6 +17,7 @@ import io.github.aeshen.observability.query.reference.demo.ReferenceBackendTrans
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class TranslatorKitTest {
@@ -92,7 +94,7 @@ class TranslatorKitTest {
             ),
             translated.sort,
         )
-        assertEquals(AuditPage(limit = 25, offset = 5), translated.page)
+        assertEquals(AuditPagination.Offset(limit = 25, offset = 5), translated.pagination)
     }
 
     private fun createQueryTranslator(): AuditSearchQueryTranslator<String, String, String, String> {
@@ -179,5 +181,42 @@ class TranslatorKitTest {
         )
         assertEquals(100, translated.limit)
         assertEquals(200, translated.offset)
+    }
+
+    @Test
+    fun `reference translator emits cursor fields when cursor pagination is used`() {
+        val translated: ReferenceBackendQuery =
+            ReferenceBackendTranslator.translate(
+                AuditSearchQuery(
+                    fromEpochMillis = 1_710_000_000_000,
+                    toEpochMillis = 1_710_003_600_000,
+                    pagination = AuditPagination.Cursor(limit = 50, after = "eyJpZCI6Imxhc3QifQ=="),
+                    sort =
+                        listOf(
+                            AuditSort(field = AuditField.TIMESTAMP_EPOCH_MILLIS, direction = AuditSortDirection.DESC),
+                            AuditSort(field = AuditField.ID, direction = AuditSortDirection.ASC),
+                        ),
+                ),
+            )
+
+        assertEquals(50, translated.limit)
+        assertEquals(0, translated.offset)
+        assertEquals("eyJpZCI6Imxhc3QifQ==", translated.cursorAfter)
+    }
+
+    @Test
+    fun `reference translator sets null cursor for offset pagination`() {
+        val translated: ReferenceBackendQuery =
+            ReferenceBackendTranslator.translate(
+                AuditSearchQuery(
+                    fromEpochMillis = 0,
+                    toEpochMillis = 100,
+                    pagination = AuditPagination.Offset(limit = 10, offset = 20),
+                ),
+            )
+
+        assertEquals(10, translated.limit)
+        assertEquals(20, translated.offset)
+        assertNull(translated.cursorAfter)
     }
 }


### PR DESCRIPTION
## What changed

Introduce AuditPagination sealed type alongside the existing AuditPage, threading cursor support through the full SPI and reference translator kit.

Added:
- AuditPagination sealed interface with Offset(limit, offset) and Cursor(after, limit) subtypes — both with @JvmOverloads for Java callers
- AuditSearchQuery.pagination field and resolvedPagination computed property; AuditSearchQuery.Builder for Java-friendly construction
- AuditQueryResult.nextCursor: String? for backends to return continuation tokens
- TranslatedAuditQuery.pagination: AuditPagination (replaces page field)
- ReferenceBackendQuery.cursorAfter: String? — populated for cursor queries, offset set to 0 in that mode
- 8 new tests covering validation, fallback behaviour, and the cursor path through the reference translator

Deprecated (not removed):
- AuditPage, AuditSearchQuery.page, TranslatedAuditQuery.page

Breaking changes (binary, query-spi only — recompilation required):
- AuditQueryResult.copy() gains nextCursor parameter
- AuditSearchQuery synthetic default constructor gains pagination parameter
- TranslatedAuditQuery constructor type changes from AuditPage to AuditPagination

closes #9

## Type of change

- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [ ] Built-in sinks / sink decorators (`Console`, `File`, `ZipFile`, `OpenTelemetry`, `Http`)
- [ ] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [ ] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`)
- [x] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [x] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [ ] Added/updated tests
- [x] Ran `./gradlew test`
- [ ] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew ktlintCheck`
- [x] Ran `./gradlew detekt`
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [x] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [ ] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [ ] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [x] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [x] Updated `CHANGELOG.md` (if needed)
- [ ] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
