### PR TITLE
Feat/query capability negotiation

### DIFF
--- a/query-spi/README.md
+++ b/query-spi/README.md
@@ -137,6 +137,73 @@ or silently fall back to offset pagination if no stable sort is present.
 Elasticsearch `search_after` payload) and handle `AuditPagination.Cursor.after` in queries.
 Backends that do not support cursors may ignore the `after` field and leave `nextCursor` as `null`.
 
+## Capability negotiation
+
+Not all backends support the same feature set. A backend can declare which capabilities it
+supports by implementing the `QueryCapabilityAware` interface alongside `AuditSearchQueryService`.
+
+### Declaring capabilities in a backend
+
+```kotlin
+class MyAuditQueryService : AuditSearchQueryService, QueryCapabilityAware {
+    override val capabilities = QueryCapabilityDescriptor(
+        setOf(
+            QueryCapability.OFFSET_PAGINATION,
+            QueryCapability.SORT,
+            QueryCapability.TEXT_SEARCH,
+        )
+    )
+
+    override fun search(query: AuditSearchQuery): AuditQueryResult {
+        TODO("map query to backend")
+    }
+}
+```
+
+Use the built-in presets when appropriate:
+
+| Preset | Included capabilities |
+|---|---|
+| `QueryCapabilityDescriptor.FULL` | All known capabilities |
+| `QueryCapabilityDescriptor.MINIMAL` | `OFFSET_PAGINATION` only |
+
+### Inspecting capabilities as a consumer
+
+```kotlin
+val caps = (queryService as? QueryCapabilityAware)?.capabilities
+    ?: QueryCapabilityDescriptor.MINIMAL  // conservative default for non-aware backends
+```
+
+### Validating a query before execution
+
+Use `QueryCapabilityValidator` to fail fast when a query requires features the backend has not
+declared:
+
+```kotlin
+// Returns a list of violations — empty means compatible.
+val violations = QueryCapabilityValidator.check(query, caps)
+
+// Throws UnsupportedQueryCapabilityException if any violations are found.
+QueryCapabilityValidator.validate(query, caps)
+```
+
+`UnsupportedQueryCapabilityException` is a subclass of `IllegalArgumentException` and carries the
+full list of `QueryCapabilityViolation` objects for programmatic inspection.
+
+### Available capabilities
+
+| Capability | Triggered when |
+|---|---|
+| `TEXT_SEARCH` | `query.text` is non-null |
+| `SORT` | `query.sort` differs from the default (single timestamp DESC) |
+| `NESTED_CRITERIA` | any criterion contains an `AuditCriterion.Group` |
+| `OFFSET_PAGINATION` | resolved pagination is `AuditPagination.Offset` |
+| `CURSOR_PAGINATION` | resolved pagination is `AuditPagination.Cursor` |
+| `PROJECTIONS` | forward-looking: not yet modelled in the shared query contract |
+
+`QueryCapabilityAware` is **opt-in** — existing `AuditSearchQueryService` implementations remain
+valid without any changes.
+
 ## Query semantics guidance
 
 Recommended semantics for portable behavior across backends:

--- a/query-spi/api/query-spi.api
+++ b/query-spi/api/query-spi.api
@@ -364,6 +364,64 @@ public final class io/github/aeshen/observability/query/AuditValue$TextList : io
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/github/aeshen/observability/query/QueryCapability : java/lang/Enum {
+	public static final field CURSOR_PAGINATION Lio/github/aeshen/observability/query/QueryCapability;
+	public static final field NESTED_CRITERIA Lio/github/aeshen/observability/query/QueryCapability;
+	public static final field OFFSET_PAGINATION Lio/github/aeshen/observability/query/QueryCapability;
+	public static final field PROJECTIONS Lio/github/aeshen/observability/query/QueryCapability;
+	public static final field SORT Lio/github/aeshen/observability/query/QueryCapability;
+	public static final field TEXT_SEARCH Lio/github/aeshen/observability/query/QueryCapability;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/aeshen/observability/query/QueryCapability;
+	public static fun values ()[Lio/github/aeshen/observability/query/QueryCapability;
+}
+
+public abstract interface class io/github/aeshen/observability/query/QueryCapabilityAware {
+	public abstract fun getCapabilities ()Lio/github/aeshen/observability/query/QueryCapabilityDescriptor;
+}
+
+public final class io/github/aeshen/observability/query/QueryCapabilityDescriptor {
+	public static final field Companion Lio/github/aeshen/observability/query/QueryCapabilityDescriptor$Companion;
+	public fun <init> (Ljava/util/Set;)V
+	public final fun component1 ()Ljava/util/Set;
+	public final fun copy (Ljava/util/Set;)Lio/github/aeshen/observability/query/QueryCapabilityDescriptor;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/QueryCapabilityDescriptor;Ljava/util/Set;ILjava/lang/Object;)Lio/github/aeshen/observability/query/QueryCapabilityDescriptor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSupported ()Ljava/util/Set;
+	public fun hashCode ()I
+	public final fun supports (Lio/github/aeshen/observability/query/QueryCapability;)Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/aeshen/observability/query/QueryCapabilityDescriptor$Companion {
+	public final fun getFULL ()Lio/github/aeshen/observability/query/QueryCapabilityDescriptor;
+	public final fun getMINIMAL ()Lio/github/aeshen/observability/query/QueryCapabilityDescriptor;
+}
+
+public final class io/github/aeshen/observability/query/QueryCapabilityValidator {
+	public static final field INSTANCE Lio/github/aeshen/observability/query/QueryCapabilityValidator;
+	public final fun check (Lio/github/aeshen/observability/query/AuditSearchQuery;Lio/github/aeshen/observability/query/QueryCapabilityDescriptor;)Ljava/util/List;
+	public final fun validate (Lio/github/aeshen/observability/query/AuditSearchQuery;Lio/github/aeshen/observability/query/QueryCapabilityDescriptor;)V
+}
+
+public final class io/github/aeshen/observability/query/QueryCapabilityViolation {
+	public fun <init> (Lio/github/aeshen/observability/query/QueryCapability;Ljava/lang/String;)V
+	public final fun component1 ()Lio/github/aeshen/observability/query/QueryCapability;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lio/github/aeshen/observability/query/QueryCapability;Ljava/lang/String;)Lio/github/aeshen/observability/query/QueryCapabilityViolation;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/query/QueryCapabilityViolation;Lio/github/aeshen/observability/query/QueryCapability;Ljava/lang/String;ILjava/lang/Object;)Lio/github/aeshen/observability/query/QueryCapabilityViolation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapability ()Lio/github/aeshen/observability/query/QueryCapability;
+	public final fun getDetail ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/aeshen/observability/query/UnsupportedQueryCapabilityException : java/lang/IllegalArgumentException {
+	public fun <init> (Ljava/util/List;)V
+	public final fun getViolations ()Ljava/util/List;
+}
+
 public abstract interface class io/github/aeshen/observability/query/reference/AuditFieldMapper {
 	public abstract fun map-Jr6fKy0 (Ljava/lang/String;)Ljava/lang/Object;
 }

--- a/query-spi/src/main/kotlin/io/github/aeshen/observability/query/QueryCapability.kt
+++ b/query-spi/src/main/kotlin/io/github/aeshen/observability/query/QueryCapability.kt
@@ -1,0 +1,38 @@
+package io.github.aeshen.observability.query
+
+/**
+ * Enumeration of query features that a backend implementation may or may not support.
+ *
+ * Use [QueryCapabilityDescriptor] to compose a set of supported capabilities, and
+ * [QueryCapabilityValidator] to validate an [AuditSearchQuery] against those capabilities
+ * before executing it.
+ *
+ * @see QueryCapabilityDescriptor
+ * @see QueryCapabilityAware
+ * @see QueryCapabilityValidator
+ */
+enum class QueryCapability {
+    /** Full-text search via [AuditSearchQuery.text] / [AuditTextQuery]. */
+    TEXT_SEARCH,
+
+    /** Custom sort order via [AuditSearchQuery.sort] (beyond the default timestamp-DESC). */
+    SORT,
+
+    /** Grouped / nested criteria via [AuditCriterion.Group]. */
+    NESTED_CRITERIA,
+
+    /** Traditional limit/offset pagination via [AuditPagination.Offset]. */
+    OFFSET_PAGINATION,
+
+    /** Keyset / cursor-based pagination via [AuditPagination.Cursor]. */
+    CURSOR_PAGINATION,
+
+    /**
+     * Field-level result projections.
+     *
+     * Forward-looking: the shared query model does not yet expose a projection field.
+     * Backends that support projections through their own extension points can declare this
+     * capability so consumers can gate on it.
+     */
+    PROJECTIONS,
+}

--- a/query-spi/src/main/kotlin/io/github/aeshen/observability/query/QueryCapabilityDescriptor.kt
+++ b/query-spi/src/main/kotlin/io/github/aeshen/observability/query/QueryCapabilityDescriptor.kt
@@ -1,0 +1,59 @@
+package io.github.aeshen.observability.query
+
+/**
+ * Describes the set of [QueryCapability] values that a backend implementation supports.
+ *
+ * Create a descriptor by listing the supported capabilities:
+ * ```kotlin
+ * val capabilities = QueryCapabilityDescriptor(
+ *     setOf(QueryCapability.OFFSET_PAGINATION, QueryCapability.SORT)
+ * )
+ * ```
+ *
+ * Use the built-in presets for common configurations:
+ * - [FULL] – all known capabilities are supported
+ * - [MINIMAL] – only offset pagination is guaranteed
+ *
+ * @see QueryCapabilityAware
+ * @see QueryCapabilityValidator
+ */
+data class QueryCapabilityDescriptor(
+    val supported: Set<QueryCapability>,
+) {
+    /** Returns `true` if [capability] is in the supported set. */
+    fun supports(capability: QueryCapability): Boolean = capability in supported
+
+    companion object {
+        /** Descriptor that declares support for every known [QueryCapability]. */
+        val FULL: QueryCapabilityDescriptor = QueryCapabilityDescriptor(QueryCapability.entries.toSet())
+
+        /**
+         * Minimal baseline descriptor: only [QueryCapability.OFFSET_PAGINATION] is guaranteed.
+         *
+         * Use this as the starting point for backends that have not yet declared their full
+         * capability surface.
+         */
+        val MINIMAL: QueryCapabilityDescriptor = QueryCapabilityDescriptor(setOf(QueryCapability.OFFSET_PAGINATION))
+    }
+}
+
+/**
+ * Optional mixin for [AuditSearchQueryService] implementations that wish to expose their
+ * supported query capabilities.
+ *
+ * Implementing this interface is **opt-in** – existing implementations remain valid without it.
+ * Consumers can introspect capabilities via a safe cast:
+ *
+ * ```kotlin
+ * val caps = (queryService as? QueryCapabilityAware)?.capabilities
+ *     ?: QueryCapabilityDescriptor.MINIMAL
+ * QueryCapabilityValidator.validate(query, caps)
+ * ```
+ *
+ * @see QueryCapabilityDescriptor
+ * @see QueryCapabilityValidator
+ */
+interface QueryCapabilityAware {
+    /** The capabilities supported by this backend implementation. */
+    val capabilities: QueryCapabilityDescriptor
+}

--- a/query-spi/src/main/kotlin/io/github/aeshen/observability/query/QueryCapabilityValidator.kt
+++ b/query-spi/src/main/kotlin/io/github/aeshen/observability/query/QueryCapabilityValidator.kt
@@ -1,0 +1,133 @@
+package io.github.aeshen.observability.query
+
+/**
+ * Describes a single capability requirement that was not satisfied by a backend's declared
+ * [QueryCapabilityDescriptor].
+ *
+ * @property capability The unsupported [QueryCapability].
+ * @property detail Human-readable explanation of which part of the query requires the capability.
+ */
+data class QueryCapabilityViolation(
+    val capability: QueryCapability,
+    val detail: String,
+)
+
+/**
+ * Thrown by [QueryCapabilityValidator.validate] when an [AuditSearchQuery] requires one or more
+ * capabilities that the backend has not declared as supported.
+ *
+ * @property violations The full list of unsatisfied capability requirements.
+ */
+class UnsupportedQueryCapabilityException(
+    val violations: List<QueryCapabilityViolation>,
+) : IllegalArgumentException(
+    buildMessage(violations),
+) {
+    init {
+        require(violations.isNotEmpty()) { "violations must not be empty." }
+    }
+
+    private companion object {
+        fun buildMessage(violations: List<QueryCapabilityViolation>): String {
+            val lines = violations.joinToString(separator = "\n  - ") { "${it.capability}: ${it.detail}" }
+            return "Query requires unsupported capabilities:\n  - $lines"
+        }
+    }
+}
+
+private val DEFAULT_SORT = listOf(AuditSort(field = AuditField.TIMESTAMP_EPOCH_MILLIS))
+
+/**
+ * Validates an [AuditSearchQuery] against a [QueryCapabilityDescriptor].
+ *
+ * Use [check] to obtain a (possibly empty) list of violations without throwing.
+ * Use [validate] to throw [UnsupportedQueryCapabilityException] on the first unsatisfied requirement.
+ *
+ * **Detection rules:**
+ * | Capability | Triggered when |
+ * |---|---|
+ * | [QueryCapability.TEXT_SEARCH] | `query.text != null` |
+ * | [QueryCapability.SORT] | sort list differs from the default (single timestamp DESC) |
+ * | [QueryCapability.NESTED_CRITERIA] | any criterion tree node is an [AuditCriterion.Group] |
+ * | [QueryCapability.OFFSET_PAGINATION] | resolved pagination is [AuditPagination.Offset] |
+ * | [QueryCapability.CURSOR_PAGINATION] | resolved pagination is [AuditPagination.Cursor] |
+ *
+ * @see QueryCapabilityDescriptor
+ * @see QueryCapabilityAware
+ */
+object QueryCapabilityValidator {
+    /**
+     * Returns every [QueryCapabilityViolation] found for [query] against [capabilities].
+     * An empty list means the query is fully compatible with the declared capabilities.
+     */
+    fun check(
+        query: AuditSearchQuery,
+        capabilities: QueryCapabilityDescriptor,
+    ): List<QueryCapabilityViolation> {
+        val violations = mutableListOf<QueryCapabilityViolation>()
+
+        if (query.text != null && !capabilities.supports(QueryCapability.TEXT_SEARCH)) {
+            violations += QueryCapabilityViolation(
+                capability = QueryCapability.TEXT_SEARCH,
+                detail = "query.text is set but the backend does not support text search.",
+            )
+        }
+
+        if (query.sort != DEFAULT_SORT && !capabilities.supports(QueryCapability.SORT)) {
+            violations += QueryCapabilityViolation(
+                capability = QueryCapability.SORT,
+                detail = "query.sort contains a non-default sort order but the backend does not support custom sorting.",
+            )
+        }
+
+        if (hasNestedCriteria(query.criteria) && !capabilities.supports(QueryCapability.NESTED_CRITERIA)) {
+            violations += QueryCapabilityViolation(
+                capability = QueryCapability.NESTED_CRITERIA,
+                detail = "query.criteria contains an AuditCriterion.Group but the backend does not support nested criteria.",
+            )
+        }
+
+        when (query.resolvedPagination) {
+            is AuditPagination.Offset ->
+                if (!capabilities.supports(QueryCapability.OFFSET_PAGINATION)) {
+                    violations += QueryCapabilityViolation(
+                        capability = QueryCapability.OFFSET_PAGINATION,
+                        detail = "resolved pagination is Offset but the backend does not support offset pagination.",
+                    )
+                }
+
+            is AuditPagination.Cursor ->
+                if (!capabilities.supports(QueryCapability.CURSOR_PAGINATION)) {
+                    violations += QueryCapabilityViolation(
+                        capability = QueryCapability.CURSOR_PAGINATION,
+                        detail = "resolved pagination is Cursor but the backend does not support cursor pagination.",
+                    )
+                }
+        }
+
+        return violations
+    }
+
+    /**
+     * Validates [query] against [capabilities] and throws [UnsupportedQueryCapabilityException]
+     * if any violations are found.
+     */
+    fun validate(
+        query: AuditSearchQuery,
+        capabilities: QueryCapabilityDescriptor,
+    ) {
+        val violations = check(query, capabilities)
+        if (violations.isNotEmpty()) {
+            throw UnsupportedQueryCapabilityException(violations)
+        }
+    }
+
+    private fun hasNestedCriteria(criteria: List<AuditCriterion>): Boolean =
+        criteria.any { criterion ->
+            when (criterion) {
+                is AuditCriterion.Group -> true
+                is AuditCriterion.Comparison -> false
+                is AuditCriterion.Exists -> false
+            }
+        }
+}

--- a/query-spi/src/main/kotlin/io/github/aeshen/observability/query/QueryCapabilityValidator.kt
+++ b/query-spi/src/main/kotlin/io/github/aeshen/observability/query/QueryCapabilityValidator.kt
@@ -21,8 +21,8 @@ data class QueryCapabilityViolation(
 class UnsupportedQueryCapabilityException(
     val violations: List<QueryCapabilityViolation>,
 ) : IllegalArgumentException(
-    buildMessage(violations),
-) {
+        buildMessage(violations),
+    ) {
     init {
         require(violations.isNotEmpty()) { "violations must not be empty." }
     }
@@ -67,42 +67,57 @@ object QueryCapabilityValidator {
         val violations = mutableListOf<QueryCapabilityViolation>()
 
         if (query.text != null && !capabilities.supports(QueryCapability.TEXT_SEARCH)) {
-            violations += QueryCapabilityViolation(
-                capability = QueryCapability.TEXT_SEARCH,
-                detail = "query.text is set but the backend does not support text search.",
-            )
+            violations +=
+                QueryCapabilityViolation(
+                    capability = QueryCapability.TEXT_SEARCH,
+                    detail = "query.text is set but the backend does not support text search.",
+                )
         }
 
         if (query.sort != DEFAULT_SORT && !capabilities.supports(QueryCapability.SORT)) {
-            violations += QueryCapabilityViolation(
-                capability = QueryCapability.SORT,
-                detail = "query.sort contains a non-default sort order but the backend does not support custom sorting.",
-            )
+            violations +=
+                QueryCapabilityViolation(
+                    capability = QueryCapability.SORT,
+                    detail =
+                        "query.sort contains a non-default sort order but the backend does not " +
+                            "support custom sorting.",
+                )
         }
 
         if (hasNestedCriteria(query.criteria) && !capabilities.supports(QueryCapability.NESTED_CRITERIA)) {
-            violations += QueryCapabilityViolation(
-                capability = QueryCapability.NESTED_CRITERIA,
-                detail = "query.criteria contains an AuditCriterion.Group but the backend does not support nested criteria.",
-            )
+            violations +=
+                QueryCapabilityViolation(
+                    capability = QueryCapability.NESTED_CRITERIA,
+                    detail =
+                        "query.criteria contains an AuditCriterion.Group but the backend does not " +
+                            "support nested criteria.",
+                )
         }
 
         when (query.resolvedPagination) {
-            is AuditPagination.Offset ->
+            is AuditPagination.Offset -> {
                 if (!capabilities.supports(QueryCapability.OFFSET_PAGINATION)) {
-                    violations += QueryCapabilityViolation(
-                        capability = QueryCapability.OFFSET_PAGINATION,
-                        detail = "resolved pagination is Offset but the backend does not support offset pagination.",
-                    )
+                    violations +=
+                        QueryCapabilityViolation(
+                            capability = QueryCapability.OFFSET_PAGINATION,
+                            detail =
+                                "resolved pagination is Offset but the backend does not " +
+                                    "support offset pagination.",
+                        )
                 }
+            }
 
-            is AuditPagination.Cursor ->
+            is AuditPagination.Cursor -> {
                 if (!capabilities.supports(QueryCapability.CURSOR_PAGINATION)) {
-                    violations += QueryCapabilityViolation(
-                        capability = QueryCapability.CURSOR_PAGINATION,
-                        detail = "resolved pagination is Cursor but the backend does not support cursor pagination.",
-                    )
+                    violations +=
+                        QueryCapabilityViolation(
+                            capability = QueryCapability.CURSOR_PAGINATION,
+                            detail =
+                                "resolved pagination is Cursor but the backend does not " +
+                                    "support cursor pagination.",
+                        )
                 }
+            }
         }
 
         return violations

--- a/query-spi/src/test/kotlin/io/github/aeshen/observability/query/QueryCapabilityTest.kt
+++ b/query-spi/src/test/kotlin/io/github/aeshen/observability/query/QueryCapabilityTest.kt
@@ -83,10 +83,11 @@ class QueryCapabilityTest {
     @Test
     fun `check does not flag default sort as SORT violation`() {
         val query = baseQuery()
-        val violations = QueryCapabilityValidator.check(
-            query,
-            QueryCapabilityDescriptor(setOf(QueryCapability.OFFSET_PAGINATION)),
-        )
+        val violations =
+            QueryCapabilityValidator.check(
+                query,
+                QueryCapabilityDescriptor(setOf(QueryCapability.OFFSET_PAGINATION)),
+            )
         assertTrue(violations.isEmpty())
     }
 
@@ -101,13 +102,23 @@ class QueryCapabilityTest {
 
     @Test
     fun `check detects NESTED_CRITERIA violation`() {
-        val group = AuditCriterion.Group(
-            operator = AuditLogicalOperator.OR,
-            criteria = listOf(
-                AuditCriterion.Comparison(AuditField.LEVEL, AuditComparisonOperator.EQ, AuditValue.Text("ERROR")),
-                AuditCriterion.Comparison(AuditField.LEVEL, AuditComparisonOperator.EQ, AuditValue.Text("WARN")),
-            ),
-        )
+        val group =
+            AuditCriterion.Group(
+                operator = AuditLogicalOperator.OR,
+                criteria =
+                    listOf(
+                        AuditCriterion.Comparison(
+                            AuditField.LEVEL,
+                            AuditComparisonOperator.EQ,
+                            AuditValue.Text("ERROR"),
+                        ),
+                        AuditCriterion.Comparison(
+                            AuditField.LEVEL,
+                            AuditComparisonOperator.EQ,
+                            AuditValue.Text("WARN"),
+                        ),
+                    ),
+            )
         val query = baseQuery(criteria = listOf(group))
         val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.MINIMAL)
         assertEquals(1, violations.size)
@@ -127,10 +138,11 @@ class QueryCapabilityTest {
     @Test
     fun `check detects OFFSET_PAGINATION violation`() {
         val query = baseQuery(pagination = AuditPagination.Offset(limit = 10, offset = 5))
-        val violations = QueryCapabilityValidator.check(
-            query,
-            QueryCapabilityDescriptor(setOf(QueryCapability.CURSOR_PAGINATION)),
-        )
+        val violations =
+            QueryCapabilityValidator.check(
+                query,
+                QueryCapabilityDescriptor(setOf(QueryCapability.CURSOR_PAGINATION)),
+            )
         assertEquals(1, violations.size)
         assertEquals(QueryCapability.OFFSET_PAGINATION, violations.single().capability)
     }
@@ -163,10 +175,11 @@ class QueryCapabilityTest {
 
     @Test
     fun `check returns multiple violations when several features are unsupported`() {
-        val query = baseQuery(
-            text = AuditTextQuery("search term"),
-            pagination = AuditPagination.Cursor(after = "abc"),
-        )
+        val query =
+            baseQuery(
+                text = AuditTextQuery("search term"),
+                pagination = AuditPagination.Cursor(after = "abc"),
+            )
         val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.MINIMAL)
         val capabilities = violations.map { it.capability }
         assertTrue(QueryCapability.TEXT_SEARCH in capabilities)
@@ -178,9 +191,10 @@ class QueryCapabilityTest {
     @Test
     fun `validate throws UnsupportedQueryCapabilityException on violations`() {
         val query = baseQuery(text = AuditTextQuery("hello"))
-        val ex = assertFailsWith<UnsupportedQueryCapabilityException> {
-            QueryCapabilityValidator.validate(query, QueryCapabilityDescriptor.MINIMAL)
-        }
+        val ex =
+            assertFailsWith<UnsupportedQueryCapabilityException> {
+                QueryCapabilityValidator.validate(query, QueryCapabilityDescriptor.MINIMAL)
+            }
         assertEquals(1, ex.violations.size)
         assertEquals(QueryCapability.TEXT_SEARCH, ex.violations.single().capability)
         assertIs<IllegalArgumentException>(ex)
@@ -203,12 +217,13 @@ class QueryCapabilityTest {
 
     @Test
     fun `UnsupportedQueryCapabilityException message contains capability names`() {
-        val ex = UnsupportedQueryCapabilityException(
-            listOf(
-                QueryCapabilityViolation(QueryCapability.TEXT_SEARCH, "text is set"),
-                QueryCapabilityViolation(QueryCapability.CURSOR_PAGINATION, "cursor used"),
-            ),
-        )
+        val ex =
+            UnsupportedQueryCapabilityException(
+                listOf(
+                    QueryCapabilityViolation(QueryCapability.TEXT_SEARCH, "text is set"),
+                    QueryCapabilityViolation(QueryCapability.CURSOR_PAGINATION, "cursor used"),
+                ),
+            )
         assertTrue(ex.message!!.contains("TEXT_SEARCH"))
         assertTrue(ex.message!!.contains("CURSOR_PAGINATION"))
     }
@@ -217,11 +232,13 @@ class QueryCapabilityTest {
 
     @Test
     fun `QueryCapabilityAware implementation exposes capabilities`() {
-        val service: AuditSearchQueryService = object : AuditSearchQueryService, QueryCapabilityAware {
-            override val capabilities = QueryCapabilityDescriptor.FULL
-            override fun search(query: AuditSearchQuery): AuditQueryResult =
-                AuditQueryResult(records = emptyList(), total = 0)
-        }
+        val service: AuditSearchQueryService =
+            object : AuditSearchQueryService, QueryCapabilityAware {
+                override val capabilities = QueryCapabilityDescriptor.FULL
+
+                override fun search(query: AuditSearchQuery): AuditQueryResult =
+                    AuditQueryResult(records = emptyList(), total = 0)
+            }
 
         val caps = (service as? QueryCapabilityAware)?.capabilities
         assertEquals(QueryCapabilityDescriptor.FULL, caps)
@@ -229,10 +246,11 @@ class QueryCapabilityTest {
 
     @Test
     fun `QueryCapabilityAware is absent when not implemented`() {
-        val service: AuditSearchQueryService = object : AuditSearchQueryService {
-            override fun search(query: AuditSearchQuery): AuditQueryResult =
-                AuditQueryResult(records = emptyList(), total = 0)
-        }
+        val service: AuditSearchQueryService =
+            object : AuditSearchQueryService {
+                override fun search(query: AuditSearchQuery): AuditQueryResult =
+                    AuditQueryResult(records = emptyList(), total = 0)
+            }
         val caps = (service as? QueryCapabilityAware)?.capabilities
         assertEquals(null, caps)
     }

--- a/query-spi/src/test/kotlin/io/github/aeshen/observability/query/QueryCapabilityTest.kt
+++ b/query-spi/src/test/kotlin/io/github/aeshen/observability/query/QueryCapabilityTest.kt
@@ -1,0 +1,255 @@
+package io.github.aeshen.observability.query
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class QueryCapabilityTest {
+    // ------------------------------------------------------------------ descriptor
+
+    @Test
+    fun `FULL descriptor supports every capability`() {
+        val descriptor = QueryCapabilityDescriptor.FULL
+        QueryCapability.entries.forEach { capability ->
+            assertTrue(descriptor.supports(capability), "FULL should support $capability")
+        }
+    }
+
+    @Test
+    fun `MINIMAL descriptor supports only offset pagination`() {
+        val descriptor = QueryCapabilityDescriptor.MINIMAL
+        assertTrue(descriptor.supports(QueryCapability.OFFSET_PAGINATION))
+        assertFalse(descriptor.supports(QueryCapability.CURSOR_PAGINATION))
+        assertFalse(descriptor.supports(QueryCapability.TEXT_SEARCH))
+        assertFalse(descriptor.supports(QueryCapability.SORT))
+        assertFalse(descriptor.supports(QueryCapability.NESTED_CRITERIA))
+        assertFalse(descriptor.supports(QueryCapability.PROJECTIONS))
+    }
+
+    @Test
+    fun `custom descriptor reflects declared set`() {
+        val descriptor = QueryCapabilityDescriptor(setOf(QueryCapability.SORT, QueryCapability.TEXT_SEARCH))
+        assertTrue(descriptor.supports(QueryCapability.SORT))
+        assertTrue(descriptor.supports(QueryCapability.TEXT_SEARCH))
+        assertFalse(descriptor.supports(QueryCapability.CURSOR_PAGINATION))
+    }
+
+    // ------------------------------------------------------------------ validator – no violations
+
+    @Test
+    fun `check returns empty list for minimal query against FULL capabilities`() {
+        val query = baseQuery()
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.FULL)
+        assertTrue(violations.isEmpty())
+    }
+
+    @Test
+    fun `check returns empty list for minimal query against MINIMAL capabilities`() {
+        val query = baseQuery()
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.MINIMAL)
+        assertTrue(violations.isEmpty())
+    }
+
+    // ------------------------------------------------------------------ validator – TEXT_SEARCH
+
+    @Test
+    fun `check detects TEXT_SEARCH violation`() {
+        val query = baseQuery(text = AuditTextQuery("hello"))
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.MINIMAL)
+        assertEquals(1, violations.size)
+        assertEquals(QueryCapability.TEXT_SEARCH, violations.single().capability)
+    }
+
+    @Test
+    fun `check accepts text query when TEXT_SEARCH is supported`() {
+        val query = baseQuery(text = AuditTextQuery("hello"))
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.FULL)
+        assertTrue(violations.isEmpty())
+    }
+
+    // ------------------------------------------------------------------ validator – SORT
+
+    @Test
+    fun `check detects SORT violation for non-default sort`() {
+        val query = baseQuery(sort = listOf(AuditSort(AuditField.LEVEL, AuditSortDirection.ASC)))
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.MINIMAL)
+        assertEquals(1, violations.size)
+        assertEquals(QueryCapability.SORT, violations.single().capability)
+    }
+
+    @Test
+    fun `check does not flag default sort as SORT violation`() {
+        val query = baseQuery()
+        val violations = QueryCapabilityValidator.check(
+            query,
+            QueryCapabilityDescriptor(setOf(QueryCapability.OFFSET_PAGINATION)),
+        )
+        assertTrue(violations.isEmpty())
+    }
+
+    @Test
+    fun `check accepts custom sort when SORT is supported`() {
+        val query = baseQuery(sort = listOf(AuditSort(AuditField.LEVEL, AuditSortDirection.ASC)))
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.FULL)
+        assertTrue(violations.isEmpty())
+    }
+
+    // ------------------------------------------------------------------ validator – NESTED_CRITERIA
+
+    @Test
+    fun `check detects NESTED_CRITERIA violation`() {
+        val group = AuditCriterion.Group(
+            operator = AuditLogicalOperator.OR,
+            criteria = listOf(
+                AuditCriterion.Comparison(AuditField.LEVEL, AuditComparisonOperator.EQ, AuditValue.Text("ERROR")),
+                AuditCriterion.Comparison(AuditField.LEVEL, AuditComparisonOperator.EQ, AuditValue.Text("WARN")),
+            ),
+        )
+        val query = baseQuery(criteria = listOf(group))
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.MINIMAL)
+        assertEquals(1, violations.size)
+        assertEquals(QueryCapability.NESTED_CRITERIA, violations.single().capability)
+    }
+
+    @Test
+    fun `check accepts flat criteria without NESTED_CRITERIA`() {
+        val flat = AuditCriterion.Comparison(AuditField.LEVEL, AuditComparisonOperator.EQ, AuditValue.Text("ERROR"))
+        val query = baseQuery(criteria = listOf(flat))
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.MINIMAL)
+        assertTrue(violations.isEmpty())
+    }
+
+    // ------------------------------------------------------------------ validator – OFFSET_PAGINATION
+
+    @Test
+    fun `check detects OFFSET_PAGINATION violation`() {
+        val query = baseQuery(pagination = AuditPagination.Offset(limit = 10, offset = 5))
+        val violations = QueryCapabilityValidator.check(
+            query,
+            QueryCapabilityDescriptor(setOf(QueryCapability.CURSOR_PAGINATION)),
+        )
+        assertEquals(1, violations.size)
+        assertEquals(QueryCapability.OFFSET_PAGINATION, violations.single().capability)
+    }
+
+    @Test
+    fun `check accepts offset pagination when OFFSET_PAGINATION is supported`() {
+        val query = baseQuery(pagination = AuditPagination.Offset(limit = 50))
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.FULL)
+        assertTrue(violations.isEmpty())
+    }
+
+    // ------------------------------------------------------------------ validator – CURSOR_PAGINATION
+
+    @Test
+    fun `check detects CURSOR_PAGINATION violation`() {
+        val query = baseQuery(pagination = AuditPagination.Cursor(after = "eyJpZCI6Imxhc3QifQ=="))
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.MINIMAL)
+        assertEquals(1, violations.size)
+        assertEquals(QueryCapability.CURSOR_PAGINATION, violations.single().capability)
+    }
+
+    @Test
+    fun `check accepts cursor pagination when CURSOR_PAGINATION is supported`() {
+        val query = baseQuery(pagination = AuditPagination.Cursor(after = "eyJpZCI6Imxhc3QifQ=="))
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.FULL)
+        assertTrue(violations.isEmpty())
+    }
+
+    // ------------------------------------------------------------------ validator – multiple violations
+
+    @Test
+    fun `check returns multiple violations when several features are unsupported`() {
+        val query = baseQuery(
+            text = AuditTextQuery("search term"),
+            pagination = AuditPagination.Cursor(after = "abc"),
+        )
+        val violations = QueryCapabilityValidator.check(query, QueryCapabilityDescriptor.MINIMAL)
+        val capabilities = violations.map { it.capability }
+        assertTrue(QueryCapability.TEXT_SEARCH in capabilities)
+        assertTrue(QueryCapability.CURSOR_PAGINATION in capabilities)
+    }
+
+    // ------------------------------------------------------------------ validate() throws
+
+    @Test
+    fun `validate throws UnsupportedQueryCapabilityException on violations`() {
+        val query = baseQuery(text = AuditTextQuery("hello"))
+        val ex = assertFailsWith<UnsupportedQueryCapabilityException> {
+            QueryCapabilityValidator.validate(query, QueryCapabilityDescriptor.MINIMAL)
+        }
+        assertEquals(1, ex.violations.size)
+        assertEquals(QueryCapability.TEXT_SEARCH, ex.violations.single().capability)
+        assertIs<IllegalArgumentException>(ex)
+    }
+
+    @Test
+    fun `validate does not throw when query is compatible`() {
+        val query = baseQuery()
+        QueryCapabilityValidator.validate(query, QueryCapabilityDescriptor.MINIMAL)
+    }
+
+    // ------------------------------------------------------------------ UnsupportedQueryCapabilityException
+
+    @Test
+    fun `UnsupportedQueryCapabilityException requires non-empty violations`() {
+        assertFailsWith<IllegalArgumentException> {
+            UnsupportedQueryCapabilityException(emptyList())
+        }
+    }
+
+    @Test
+    fun `UnsupportedQueryCapabilityException message contains capability names`() {
+        val ex = UnsupportedQueryCapabilityException(
+            listOf(
+                QueryCapabilityViolation(QueryCapability.TEXT_SEARCH, "text is set"),
+                QueryCapabilityViolation(QueryCapability.CURSOR_PAGINATION, "cursor used"),
+            ),
+        )
+        assertTrue(ex.message!!.contains("TEXT_SEARCH"))
+        assertTrue(ex.message!!.contains("CURSOR_PAGINATION"))
+    }
+
+    // ------------------------------------------------------------------ QueryCapabilityAware contract
+
+    @Test
+    fun `QueryCapabilityAware implementation exposes capabilities`() {
+        val service: AuditSearchQueryService = object : AuditSearchQueryService, QueryCapabilityAware {
+            override val capabilities = QueryCapabilityDescriptor.FULL
+            override fun search(query: AuditSearchQuery): AuditQueryResult =
+                AuditQueryResult(records = emptyList(), total = 0)
+        }
+
+        val caps = (service as? QueryCapabilityAware)?.capabilities
+        assertEquals(QueryCapabilityDescriptor.FULL, caps)
+    }
+
+    @Test
+    fun `QueryCapabilityAware is absent when not implemented`() {
+        val service: AuditSearchQueryService = object : AuditSearchQueryService {
+            override fun search(query: AuditSearchQuery): AuditQueryResult =
+                AuditQueryResult(records = emptyList(), total = 0)
+        }
+        val caps = (service as? QueryCapabilityAware)?.capabilities
+        assertEquals(null, caps)
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private fun baseQuery(
+        text: AuditTextQuery? = null,
+        sort: List<AuditSort> = listOf(AuditSort(field = AuditField.TIMESTAMP_EPOCH_MILLIS)),
+        criteria: List<AuditCriterion> = emptyList(),
+        pagination: AuditPagination? = null,
+    ) = AuditSearchQuery(
+        fromEpochMillis = 0L,
+        toEpochMillis = 1000L,
+        text = text,
+        sort = sort,
+        criteria = criteria,
+        pagination = pagination,
+    )
+}


### PR DESCRIPTION
## What changed

Introduce AuditPagination sealed type alongside the existing AuditPage,
threading cursor support through the full SPI and reference translator kit.

Added:
- AuditPagination sealed interface with Offset(limit, offset) and
  Cursor(after, limit) subtypes — both with @JvmOverloads for Java callers
- AuditSearchQuery.pagination field and resolvedPagination computed property;
  AuditSearchQuery.Builder for Java-friendly construction
- AuditQueryResult.nextCursor: String? for backends to return continuation tokens
- TranslatedAuditQuery.pagination: AuditPagination (replaces page field)
- ReferenceBackendQuery.cursorAfter: String? — populated for cursor queries,
  offset set to 0 in that mode
- 8 new tests covering validation, fallback behaviour, and the cursor path
  through the reference translator

Deprecated (not removed):
- AuditPage, AuditSearchQuery.page, TranslatedAuditQuery.page

Breaking changes (binary, query-spi only — recompilation required):
- AuditQueryResult.copy() gains nextCursor parameter
- AuditSearchQuery synthetic default constructor gains pagination parameter
- TranslatedAuditQuery constructor type changes from AuditPage to AuditPagination

closes #9

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [ ] Built-in sinks / sink decorators (`Console`, `File`, `ZipFile`, `OpenTelemetry`, `Http`)
- [ ] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [ ] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`)
- [x] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [ ] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [ ] Added/updated tests
- [x] Ran `./gradlew test`
- [ ] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew ktlintCheck`
- [x] Ran `./gradlew detekt`
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [x] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [ ] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [ ] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [x] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [ ] Updated `CHANGELOG.md` (if needed)
- [ ] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
