### PR TITLE
feat: add Kafka, Webhook, S3, and Redis Streams sinks (#11)

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,6 +4,44 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
+  <component name="NullableNotNullManager">
+    <option name="myDefaultNullable" value="org.jetbrains.annotations.Nullable" />
+    <option name="myDefaultNotNull" value="org.jetbrains.annotations.NotNull" />
+    <option name="myOrdered" value="false" />
+    <option name="myNullables">
+      <value>
+        <list size="11">
+          <item index="0" class="java.lang.String" itemvalue="org.jspecify.annotations.Nullable" />
+          <item index="1" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="3" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="4" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
+          <item index="5" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
+          <item index="6" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="7" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
+          <item index="8" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
+          <item index="9" class="java.lang.String" itemvalue="org.springframework.lang.Nullable" />
+          <item index="10" class="java.lang.String" itemvalue="jakarta.annotation.Nullable" />
+        </list>
+      </value>
+    </option>
+    <option name="myNotNulls">
+      <value>
+        <list size="10">
+          <item index="0" class="java.lang.String" itemvalue="org.jspecify.annotations.NonNull" />
+          <item index="1" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
+          <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="3" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="4" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
+          <item index="5" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
+          <item index="6" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+          <item index="7" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
+          <item index="8" class="java.lang.String" itemvalue="org.springframework.lang.NonNull" />
+          <item index="9" class="java.lang.String" itemvalue="jakarta.annotation.Nonnull" />
+        </list>
+      </value>
+    </option>
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_24" default="true" project-jdk-name="temurin-24" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 ## [Unreleased]
 
 ### Added
+- **Expanded built-in sink ecosystem** (issue #11) — four new production-ready sinks, all optional-dependency-safe (missing runtime deps produce a clear `IllegalStateException` with guidance):
+  - **`Kafka`** — produces encoded events as `ProducerRecord<String, ByteArray>` to a configurable topic; event name used as partition key; SASL/SSL and any other producer settings passed via `additionalProperties`. Optional dep: `org.apache.kafka:kafka-clients`.
+  - **`Webhook`** — HTTP POST with HMAC-SHA256 request signing (`sha256=<hex>` in a configurable header, defaulting to `X-Hub-Signature-256`, compatible with GitHub-style webhook consumers). No new runtime dependency — uses JDK `javax.crypto.Mac`.
+  - **`S3`** — archives events as gzip-compressed JSONL objects to S3-compatible storage; keys follow a `{prefix}/{yyyy/MM/dd/HH}/{uuid}.jsonl.gz` pattern for natural time-partitioning; implements `BatchCapableObservabilitySink` so batching reduces upload frequency when composed with `BatchingObservabilitySink`; custom `endpoint` enables MinIO and Cloudflare R2. Optional dep: `software.amazon.awssdk:s3`.
+  - **`Redis`** — publishes events to a Redis Stream via `XADD` with optional approximate MAXLEN trimming; connection is established lazily on first use so construction never blocks; command timeout applied via `RedisURI`. Optional dep: `io.lettuce:lettuce-core`.
 - **Query capability negotiation** in `query-spi` (issue #10):
   - New `QueryCapability` enum declaring all query features a backend may support: `TEXT_SEARCH`, `SORT`, `NESTED_CRITERIA`, `OFFSET_PAGINATION`, `CURSOR_PAGINATION`, `PROJECTIONS`.
   - New `QueryCapabilityDescriptor` — immutable set of supported capabilities with a `supports(capability)` helper and two built-in presets: `FULL` (all capabilities) and `MINIMAL` (offset pagination only).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An opinionated, production-ready Kotlin framework for structured application observability.
 
-Provides a single, type-safe entry point to emit structured events with typed context metadata and route them through a processing pipeline to one or more configurable sinks (console, SLF4J, file, zip, OpenTelemetry), with optional encryption, async delivery, batching, and retry.
+Provides a single, type-safe entry point to emit structured events with typed context metadata and route them through a processing pipeline to one or more configurable sinks (console, SLF4J, file, zip, OpenTelemetry, Kafka), with optional encryption, async delivery, batching, and retry.
 
 ## Table of Contents
 
@@ -78,7 +78,7 @@ Sinks (fan-out)      (write to Console, File, OpenTelemetry, …)
 
 - **Unified event API** — `trace`, `debug`, `info`, `warn`, `error`, and `emit`
 - **Type-safe context** — typed keys (`StringKey`, `LongKey`, `DoubleKey`, `BooleanKey`) and namespaced key grouping
-- **Multiple sinks with fan-out** — Console, SLF4J, File (JSONL), ZipFile, OpenTelemetry OTLP
+- **Multiple sinks with fan-out** — Console, SLF4J, File (JSONL), ZipFile, OpenTelemetry OTLP, Kafka
 - **Optional encryption** — AES-GCM with a fixed key, or per-event data key wrapped with RSA-OAEP-256
 - **Sensitive-field filtering** — ordered allow/mask/remove processors for `context.*`, `metadata.*`, `message`, and `payload`
 - **Reliability decorators** — `AsyncObservabilitySink`, `BatchingObservabilitySink`, `RetryingObservabilitySink`
@@ -460,6 +460,35 @@ val config =
                 maxExportBatchSize = 512,
                 headers = mapOf("Authorization" to "Bearer token"),
             ),
+            Kafka(
+                bootstrapServers = "broker1:9092,broker2:9092",
+                topic = "observability-events",
+                clientId = "my-service-observability",
+                timeoutMillis = 5_000,
+                // additionalProperties can carry SASL/SSL settings or any producer config
+                additionalProperties = mapOf(
+                    "security.protocol" to "SASL_SSL",
+                    "sasl.mechanism" to "PLAIN",
+                ),
+            ),
+            Webhook(
+                endpoint = "https://hooks.example.com/observability",
+                secret = "my-signing-secret",
+                signatureHeader = "X-Hub-Signature-256",
+                headers = mapOf("Content-Type" to "application/json"),
+            ),
+            S3(
+                bucket = "my-observability-archive",
+                region = "eu-west-1",
+                keyPrefix = "events/",
+                timeoutMillis = 30_000,
+                // endpoint = "http://localhost:9000"  // optional: MinIO / R2 / compatible storage
+            ),
+            Redis(
+                uri = "redis://localhost:6379",
+                streamKey = "observability:events",
+                maxlen = 100_000,   // optional: approximate MAXLEN trimming
+            ),
         ),
         failOnSinkError = false, // best-effort (default)
     )
@@ -473,6 +502,10 @@ val config =
 | `ZipFile`        | Appends JSONL entries to a ZIP archive, preserving existing entries via startup replay | None                                              |
 | `Http`           | Sends encoded payload bytes to an arbitrary HTTP/HTTPS endpoint (`POST`, `PUT`, `PATCH`) | None                                              |
 | `OpenTelemetry`  | Exports via OTLP HTTP to any OTel-compatible backend      | `opentelemetry-api`, `-sdk`, `-exporter-otlp`     |
+| `Kafka`          | Produces encoded events to a Kafka topic; supports SASL/SSL via `additionalProperties` | `org.apache.kafka:kafka-clients`                  |
+| `Webhook`        | HTTP POST with HMAC-SHA256 request signature; compatible with GitHub-style webhook consumers | None                                              |
+| `S3`             | Uploads events as gzipped JSONL objects to S3-compatible storage; one upload per event or batch | `software.amazon.awssdk:s3`                       |
+| `Redis`          | Publishes events to a Redis Stream (`XADD`) with optional approximate MAXLEN trimming | `io.lettuce:lettuce-core`                         |
 
 All sinks receive fan-out delivery. `IllegalArgumentException` and `IllegalStateException` from one sink do not block others (unless `failOnSinkError = true`).
 
@@ -481,6 +514,35 @@ All sinks receive fan-out delivery. `IllegalArgumentException` and `IllegalState
 - `timeoutMillis` applies to request connect/send timing.
 - Any non-2xx response throws `IllegalStateException` (so `RetryingObservabilitySink` can retry).
 - Transport errors (`IOException`, `InterruptedException`) are surfaced as `IllegalStateException`.
+
+`Kafka` sink behavior:
+
+- Each event is published as a `ProducerRecord` where the key is the resolved event name (from metadata), falling back to `"observability"` if absent.
+- `timeoutMillis` governs the synchronous `Future.get()` call on send and the graceful `producer.close()` duration.
+- Send failures and timeouts surface as `IllegalStateException` (compatible with `RetryingObservabilitySink`).
+- `additionalProperties` is passed directly to the underlying `KafkaProducer`, enabling SASL/SSL, compression, and other standard producer settings.
+- `kafka-clients` must be present on the runtime classpath; a missing dependency produces a clear `IllegalStateException` with instructions.
+
+`Webhook` sink behavior:
+
+- Each event payload is sent as an HTTP POST body to `endpoint`.
+- If `secret` is non-empty, an HMAC-SHA256 signature is computed over the payload and added as `sha256=<hex>` in `signatureHeader` (default `X-Hub-Signature-256`).
+- Any non-2xx response or network error surfaces as `IllegalStateException` (compatible with `RetryingObservabilitySink`).
+- `timeoutMillis` governs JDK `HttpURLConnection` connect and read timeouts.
+
+`S3` sink behavior:
+
+- Each event (or batch when using `BatchCapableObservabilitySink`) is gzip-compressed and uploaded as a JSONL object.
+- Object keys follow the pattern `{keyPrefix}{yyyy/MM/dd/HH}/{uuid}.jsonl.gz` for natural time partitioning.
+- Set `endpoint` for MinIO, Cloudflare R2, or other S3-compatible storage (path-style access is enabled automatically).
+- `software.amazon.awssdk:s3` must be on the runtime classpath; a missing dependency produces a clear `IllegalStateException` with instructions.
+
+`Redis` sink behavior:
+
+- Events are appended to the configured Redis Stream via `XADD`, with `eventName` and `payload` as message fields.
+- The Lettuce connection is established lazily on the first `handle()` call — construction never blocks even if Redis is unreachable.
+- Set `maxlen` to enable approximate MAXLEN trimming (uses `~` mode for efficiency); leave unset for unlimited stream growth.
+- `io.lettuce:lettuce-core` must be on the runtime classpath; a missing dependency produces a clear `IllegalStateException` with instructions.
 
 ### Default JSONL Format
 

--- a/api/observability.api
+++ b/api/observability.api
@@ -277,6 +277,29 @@ public final class io/github/aeshen/observability/config/sink/HttpMethod : java/
 	public static fun values ()[Lio/github/aeshen/observability/config/sink/HttpMethod;
 }
 
+public final class io/github/aeshen/observability/config/sink/Kafka : io/github/aeshen/observability/config/sink/SinkConfig {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;J)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;J)Lio/github/aeshen/observability/config/sink/Kafka;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/config/sink/Kafka;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;JILjava/lang/Object;)Lio/github/aeshen/observability/config/sink/Kafka;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdditionalProperties ()Ljava/util/Map;
+	public final fun getBootstrapServers ()Ljava/lang/String;
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getTimeoutMillis ()J
+	public final fun getTopic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/github/aeshen/observability/config/sink/OpenTelemetry : io/github/aeshen/observability/config/sink/SinkConfig {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;JJII)V
@@ -306,6 +329,49 @@ public final class io/github/aeshen/observability/config/sink/OpenTelemetry : io
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/github/aeshen/observability/config/sink/Redis : io/github/aeshen/observability/config/sink/SinkConfig {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;J)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;J)Lio/github/aeshen/observability/config/sink/Redis;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/config/sink/Redis;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;JILjava/lang/Object;)Lio/github/aeshen/observability/config/sink/Redis;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxlen ()Ljava/lang/Long;
+	public final fun getStreamKey ()Ljava/lang/String;
+	public final fun getTimeoutMillis ()J
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/aeshen/observability/config/sink/S3 : io/github/aeshen/observability/config/sink/SinkConfig {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;J)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;J)Lio/github/aeshen/observability/config/sink/S3;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/config/sink/S3;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lio/github/aeshen/observability/config/sink/S3;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBucket ()Ljava/lang/String;
+	public final fun getEndpoint ()Ljava/lang/String;
+	public final fun getKeyPrefix ()Ljava/lang/String;
+	public final fun getRegion ()Ljava/lang/String;
+	public final fun getTimeoutMillis ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class io/github/aeshen/observability/config/sink/SinkConfig {
 }
 
@@ -316,6 +382,29 @@ public final class io/github/aeshen/observability/config/sink/Slf4j : io/github/
 	public static synthetic fun copy$default (Lio/github/aeshen/observability/config/sink/Slf4j;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lio/github/aeshen/observability/config/sink/Slf4j;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLogger ()Lkotlin/reflect/KClass;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/aeshen/observability/config/sink/Webhook : io/github/aeshen/observability/config/sink/SinkConfig {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;J)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;J)Lio/github/aeshen/observability/config/sink/Webhook;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/config/sink/Webhook;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;JILjava/lang/Object;)Lio/github/aeshen/observability/config/sink/Webhook;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEndpoint ()Ljava/lang/String;
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getSecret ()Ljava/lang/String;
+	public final fun getSignatureHeader ()Ljava/lang/String;
+	public final fun getTimeoutMillis ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,9 @@ dependencies {
     compileOnly("io.opentelemetry:opentelemetry-exporter-otlp:$openTelemetryVersion")
     compileOnly("org.slf4j:slf4j-api:2.0.17")
     compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+    compileOnly("org.apache.kafka:kafka-clients:3.9.0")
+    compileOnly("software.amazon.awssdk:s3:2.29.0")
+    compileOnly("io.lettuce:lettuce-core:6.3.2.RELEASE")
 
     testImplementation(kotlin("test"))
     testImplementation(testFixtures(project(":")))
@@ -86,6 +89,10 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
     testImplementation("com.networknt:json-schema-validator:1.5.8")
+    testImplementation("org.apache.kafka:kafka-clients:3.9.0")
+    testImplementation("software.amazon.awssdk:s3:2.29.0")
+    testImplementation("software.amazon.awssdk:url-connection-client:2.29.0")
+    testImplementation("io.lettuce:lettuce-core:6.3.2.RELEASE")
 
     testFixturesApi(kotlin("test"))
 }

--- a/src/main/kotlin/io/github/aeshen/observability/config/sink/Kafka.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/config/sink/Kafka.kt
@@ -1,0 +1,18 @@
+package io.github.aeshen.observability.config.sink
+
+data class Kafka
+    @JvmOverloads
+    constructor(
+        val bootstrapServers: String,
+        val topic: String,
+        val clientId: String = "observability-sink",
+        val additionalProperties: Map<String, String> = emptyMap(),
+        val timeoutMillis: Long = 5_000,
+    ) : SinkConfig {
+        init {
+            require(bootstrapServers.isNotBlank()) { "bootstrapServers must not be blank." }
+            require(topic.isNotBlank()) { "topic must not be blank." }
+            require(clientId.isNotBlank()) { "clientId must not be blank." }
+            require(timeoutMillis > 0) { "timeoutMillis must be greater than 0." }
+        }
+    }

--- a/src/main/kotlin/io/github/aeshen/observability/config/sink/Redis.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/config/sink/Redis.kt
@@ -1,0 +1,17 @@
+package io.github.aeshen.observability.config.sink
+
+data class Redis
+    @JvmOverloads
+    constructor(
+        val uri: String,
+        val streamKey: String,
+        val maxlen: Long? = null,
+        val timeoutMillis: Long = 5_000,
+    ) : SinkConfig {
+        init {
+            require(uri.isNotBlank()) { "uri must not be blank." }
+            require(streamKey.isNotBlank()) { "streamKey must not be blank." }
+            require(timeoutMillis > 0) { "timeoutMillis must be greater than 0." }
+            maxlen?.let { require(it > 0) { "maxlen must be greater than 0 when specified." } }
+        }
+    }

--- a/src/main/kotlin/io/github/aeshen/observability/config/sink/S3.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/config/sink/S3.kt
@@ -1,0 +1,24 @@
+package io.github.aeshen.observability.config.sink
+
+import java.net.URI
+
+data class S3
+    @JvmOverloads
+    constructor(
+        val bucket: String,
+        val region: String,
+        val keyPrefix: String = "observability/",
+        val endpoint: String? = null,
+        val timeoutMillis: Long = 30_000,
+    ) : SinkConfig {
+        init {
+            require(bucket.isNotBlank()) { "bucket must not be blank." }
+            require(region.isNotBlank()) { "region must not be blank." }
+            require(keyPrefix.isNotBlank()) { "keyPrefix must not be blank." }
+            require(timeoutMillis > 0) { "timeoutMillis must be greater than 0." }
+            endpoint?.let { ep ->
+                val uri = URI.create(ep)
+                require(uri.isAbsolute) { "endpoint must be an absolute URI." }
+            }
+        }
+    }

--- a/src/main/kotlin/io/github/aeshen/observability/config/sink/Webhook.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/config/sink/Webhook.kt
@@ -1,0 +1,27 @@
+package io.github.aeshen.observability.config.sink
+
+import java.net.URI
+
+data class Webhook
+    @JvmOverloads
+    constructor(
+        val endpoint: String,
+        val secret: String,
+        val signatureHeader: String = "X-Hub-Signature-256",
+        val headers: Map<String, String> = emptyMap(),
+        val timeoutMillis: Long = 5_000,
+    ) : SinkConfig {
+        init {
+            require(endpoint.isNotBlank()) { "endpoint must not be blank." }
+            require(secret.isNotBlank()) { "secret must not be blank." }
+            require(signatureHeader.isNotBlank()) { "signatureHeader must not be blank." }
+            require(timeoutMillis > 0) { "timeoutMillis must be greater than 0." }
+            require(headers.keys.none { it.isBlank() }) { "headers must not contain blank keys." }
+
+            val uri = URI.create(endpoint)
+            require(uri.isAbsolute) { "endpoint must be an absolute URI." }
+            require(uri.scheme == "http" || uri.scheme == "https") {
+                "endpoint must use http or https scheme."
+            }
+        }
+    }

--- a/src/main/kotlin/io/github/aeshen/observability/sink/impl/KafkaObservabilitySink.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/sink/impl/KafkaObservabilitySink.kt
@@ -1,0 +1,62 @@
+package io.github.aeshen.observability.sink.impl
+
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.config.sink.Kafka
+import io.github.aeshen.observability.sink.ObservabilitySink
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.apache.kafka.common.serialization.StringSerializer
+import java.time.Duration
+import java.util.Properties
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+private const val DEFAULT_EVENT_KEY = "observability"
+
+internal class KafkaObservabilitySink internal constructor(
+    private val producer: Producer<String, ByteArray>,
+    private val topic: String,
+    private val timeoutMillis: Long,
+) : ObservabilitySink {
+    constructor(config: Kafka) : this(
+        producer = buildProducer(config),
+        topic = config.topic,
+        timeoutMillis = config.timeoutMillis,
+    )
+
+    override fun handle(event: EncodedEvent) {
+        val key = event.metadata["event"] as? String ?: DEFAULT_EVENT_KEY
+        val record = ProducerRecord(topic, key, event.encoded)
+        try {
+            producer.send(record).get(timeoutMillis, TimeUnit.MILLISECONDS)
+        } catch (e: ExecutionException) {
+            throw IllegalStateException("Kafka sink failed to send record to topic=$topic.", e.cause ?: e)
+        } catch (e: TimeoutException) {
+            throw IllegalStateException(
+                "Kafka sink timed out sending record to topic=$topic after ${timeoutMillis}ms.",
+                e,
+            )
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw IllegalStateException("Kafka sink send interrupted for topic=$topic.", e)
+        }
+    }
+
+    override fun close() {
+        producer.close(Duration.ofMillis(timeoutMillis))
+    }
+}
+
+private fun buildProducer(config: Kafka): KafkaProducer<String, ByteArray> {
+    val props = Properties()
+    props[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = config.bootstrapServers
+    props[ProducerConfig.CLIENT_ID_CONFIG] = config.clientId
+    props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java.name
+    props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = ByteArraySerializer::class.java.name
+    config.additionalProperties.forEach { (k, v) -> props[k] = v }
+    return KafkaProducer(props)
+}

--- a/src/main/kotlin/io/github/aeshen/observability/sink/impl/RedisObservabilitySink.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/sink/impl/RedisObservabilitySink.kt
@@ -1,0 +1,74 @@
+package io.github.aeshen.observability.sink.impl
+
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.config.sink.Redis
+import io.github.aeshen.observability.sink.ObservabilitySink
+import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisException
+import io.lettuce.core.RedisURI
+import io.lettuce.core.XAddArgs
+import io.lettuce.core.api.StatefulRedisConnection
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+import kotlin.time.toJavaDuration
+
+private const val DEFAULT_EVENT_KEY = "observability"
+
+internal class RedisObservabilitySink internal constructor(
+    private val publisher: RedisPublisher,
+    private val closeAction: (() -> Unit)? = null,
+) : ObservabilitySink {
+    override fun handle(event: EncodedEvent) {
+        val eventName = event.metadata["event"] as? String ?: DEFAULT_EVENT_KEY
+        val payload = event.encoded.toString(Charsets.UTF_8)
+        publisher.publish(eventName, payload)
+    }
+
+    override fun close() {
+        closeAction?.invoke()
+    }
+
+    companion object {
+        fun fromConfig(config: Redis): RedisObservabilitySink {
+            val redisUri = RedisURI.create(config.uri)
+            redisUri.timeout = config.timeoutMillis.toDuration(DurationUnit.MILLISECONDS).toJavaDuration()
+            val client = RedisClient.create(redisUri)
+            val xaddArgs = config.maxlen?.let { maxLen -> XAddArgs().maxlen(maxLen) }
+            // Connection is established lazily on the first handle() call.
+            var connection: StatefulRedisConnection<String, String>? = null
+
+            return RedisObservabilitySink(
+                publisher =
+                    { eventName, payload ->
+                        try {
+                            val conn =
+                                synchronized(client) {
+                                    connection ?: client.connect().also { connection = it }
+                                }
+                            conn.sync().xadd(
+                                config.streamKey,
+                                xaddArgs ?: XAddArgs(),
+                                mapOf("event" to eventName, "payload" to payload),
+                            )
+                        } catch (e: RedisException) {
+                            throw IllegalStateException(
+                                "Redis sink failed to publish to stream=${config.streamKey} on ${config.uri}.",
+                                e,
+                            )
+                        }
+                    },
+                closeAction = {
+                    synchronized(client) { connection?.close() }
+                    client.shutdown()
+                },
+            )
+        }
+    }
+}
+
+internal fun interface RedisPublisher {
+    fun publish(
+        eventName: String,
+        payload: String,
+    )
+}

--- a/src/main/kotlin/io/github/aeshen/observability/sink/impl/S3ObservabilitySink.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/sink/impl/S3ObservabilitySink.kt
@@ -1,0 +1,100 @@
+package io.github.aeshen.observability.sink.impl
+
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.config.sink.S3
+import io.github.aeshen.observability.sink.BatchCapableObservabilitySink
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import java.io.ByteArrayOutputStream
+import java.net.URI
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+import java.util.zip.GZIPOutputStream
+
+private val DATE_PATH_FORMATTER: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy/MM/dd/HH").withZone(ZoneOffset.UTC)
+
+internal class S3ObservabilitySink internal constructor(
+    private val uploader: S3Uploader,
+    private val keyPrefix: String,
+    private val closeAction: (() -> Unit)? = null,
+) : BatchCapableObservabilitySink {
+    override fun handle(event: EncodedEvent) {
+        handleBatch(listOf(event))
+    }
+
+    override fun handleBatch(events: List<EncodedEvent>) {
+        if (events.isEmpty()) return
+        val key = buildKey()
+        val bytes = compress(events)
+        uploader.upload(key, bytes)
+    }
+
+    override fun close() {
+        closeAction?.invoke()
+    }
+
+    private fun buildKey(): String {
+        val datePath = DATE_PATH_FORMATTER.format(Instant.now())
+        return "$keyPrefix$datePath/${UUID.randomUUID()}.jsonl.gz"
+    }
+
+    private fun compress(events: List<EncodedEvent>): ByteArray {
+        val baos = ByteArrayOutputStream()
+        GZIPOutputStream(baos).use { gz ->
+            events.forEach { event ->
+                gz.write(event.encoded)
+                if (event.encoded.lastOrNull() != '\n'.code.toByte()) {
+                    gz.write('\n'.code)
+                }
+            }
+        }
+        return baos.toByteArray()
+    }
+
+    companion object {
+        fun fromConfig(config: S3): S3ObservabilitySink {
+            val clientBuilder =
+                S3Client
+                    .builder()
+                    .region(Region.of(config.region))
+                    .overrideConfiguration { c ->
+                        c.apiCallTimeout(Duration.ofMillis(config.timeoutMillis))
+                    }
+
+            config.endpoint?.let { ep ->
+                clientBuilder
+                    .endpointOverride(URI.create(ep))
+                    .serviceConfiguration { s3Config -> s3Config.pathStyleAccessEnabled(true) }
+            }
+
+            val client = clientBuilder.build()
+            val uploader =
+                S3Uploader { key, bytes ->
+                    client.putObject(
+                        PutObjectRequest
+                            .builder()
+                            .bucket(config.bucket)
+                            .key(key)
+                            .contentType("application/gzip")
+                            .build(),
+                        RequestBody.fromBytes(bytes),
+                    )
+                }
+
+            return S3ObservabilitySink(uploader, config.keyPrefix) { client.close() }
+        }
+    }
+}
+
+internal fun interface S3Uploader {
+    fun upload(
+        key: String,
+        bytes: ByteArray,
+    )
+}

--- a/src/main/kotlin/io/github/aeshen/observability/sink/impl/WebhookObservabilitySink.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/sink/impl/WebhookObservabilitySink.kt
@@ -1,0 +1,69 @@
+package io.github.aeshen.observability.sink.impl
+
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.config.sink.Webhook
+import io.github.aeshen.observability.sink.ObservabilitySink
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+private const val HTTP_SUCCESS_MIN = 200
+private const val HTTP_SUCCESS_MAX = 299
+private const val HMAC_SHA256 = "HmacSHA256"
+
+internal class WebhookObservabilitySink internal constructor(
+    private val endpoint: URI,
+    private val signingKey: SecretKeySpec,
+    private val signatureHeader: String,
+    private val headers: Map<String, String>,
+    private val timeoutMillis: Long,
+    private val client: HttpClient,
+) : ObservabilitySink {
+    constructor(config: Webhook) : this(
+        endpoint = URI.create(config.endpoint),
+        signingKey = SecretKeySpec(config.secret.toByteArray(Charsets.UTF_8), HMAC_SHA256),
+        signatureHeader = config.signatureHeader,
+        headers = config.headers,
+        timeoutMillis = config.timeoutMillis,
+        client = HttpClient.newBuilder().connectTimeout(Duration.ofMillis(config.timeoutMillis)).build(),
+    )
+
+    override fun handle(event: EncodedEvent) {
+        val signature = sign(event.encoded)
+        val allHeaders = headers + mapOf(signatureHeader to signature)
+
+        val requestBuilder =
+            HttpRequest
+                .newBuilder(endpoint)
+                .POST(HttpRequest.BodyPublishers.ofByteArray(event.encoded))
+                .timeout(Duration.ofMillis(timeoutMillis))
+
+        allHeaders.forEach { (name, value) -> requestBuilder.header(name, value) }
+
+        val response = send(requestBuilder.build())
+        check(response.statusCode() in HTTP_SUCCESS_MIN..HTTP_SUCCESS_MAX) {
+            "Webhook sink request failed with status=${response.statusCode()} for endpoint=$endpoint."
+        }
+    }
+
+    private fun sign(bytes: ByteArray): String {
+        val mac = Mac.getInstance(HMAC_SHA256)
+        mac.init(signingKey)
+        return "sha256=" + mac.doFinal(bytes).joinToString("") { "%02x".format(it) }
+    }
+
+    private fun send(request: HttpRequest): HttpResponse<Void> =
+        try {
+            client.send(request, HttpResponse.BodyHandlers.discarding())
+        } catch (e: IOException) {
+            throw IllegalStateException("Webhook sink request failed for endpoint=$endpoint.", e)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw IllegalStateException("Webhook sink request interrupted for endpoint=$endpoint.", e)
+        }
+}

--- a/src/main/kotlin/io/github/aeshen/observability/sink/registry/SinkRegistry.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/sink/registry/SinkRegistry.kt
@@ -3,16 +3,24 @@ package io.github.aeshen.observability.sink.registry
 import io.github.aeshen.observability.config.sink.Console
 import io.github.aeshen.observability.config.sink.File
 import io.github.aeshen.observability.config.sink.Http
+import io.github.aeshen.observability.config.sink.Kafka
 import io.github.aeshen.observability.config.sink.OpenTelemetry
+import io.github.aeshen.observability.config.sink.Redis
+import io.github.aeshen.observability.config.sink.S3
 import io.github.aeshen.observability.config.sink.SinkConfig
 import io.github.aeshen.observability.config.sink.Slf4j
+import io.github.aeshen.observability.config.sink.Webhook
 import io.github.aeshen.observability.config.sink.ZipFile
 import io.github.aeshen.observability.sink.ObservabilitySink
 import io.github.aeshen.observability.sink.impl.ConsoleObservabilitySink
 import io.github.aeshen.observability.sink.impl.FileObservabilitySink
 import io.github.aeshen.observability.sink.impl.HttpObservabilitySink
+import io.github.aeshen.observability.sink.impl.KafkaObservabilitySink
 import io.github.aeshen.observability.sink.impl.OpenTelemetryObservabilitySink
+import io.github.aeshen.observability.sink.impl.RedisObservabilitySink
+import io.github.aeshen.observability.sink.impl.S3ObservabilitySink
 import io.github.aeshen.observability.sink.impl.Slf4JObservabilitySink
+import io.github.aeshen.observability.sink.impl.WebhookObservabilitySink
 import io.github.aeshen.observability.sink.impl.ZipFileObservabilitySink
 
 class SinkRegistry private constructor(
@@ -88,6 +96,10 @@ private object BuiltInSinkProvider : SinkProvider {
                 createOptionalSink("OpenTelemetry OTLP") {
                     OpenTelemetryObservabilitySink.fromConfig(config)
                 }
+            is Kafka -> createOptionalSink("Kafka") { KafkaObservabilitySink(config) }
+            is Webhook -> WebhookObservabilitySink(config)
+            is S3 -> createOptionalSink("S3") { S3ObservabilitySink.fromConfig(config) }
+            is Redis -> createOptionalSink("Redis Streams") { RedisObservabilitySink.fromConfig(config) }
             else -> null
         }
 

--- a/src/test/kotlin/io/github/aeshen/observability/config/sink/KafkaConfigTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/config/sink/KafkaConfigTest.kt
@@ -1,0 +1,59 @@
+package io.github.aeshen.observability.config.sink
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class KafkaConfigTest {
+    @Test
+    fun `valid config constructs successfully`() {
+        val config = Kafka(bootstrapServers = "localhost:9092", topic = "events")
+        assertEquals("localhost:9092", config.bootstrapServers)
+        assertEquals("events", config.topic)
+        assertEquals("observability-sink", config.clientId)
+        assertEquals(emptyMap(), config.additionalProperties)
+        assertEquals(5_000L, config.timeoutMillis)
+    }
+
+    @Test
+    fun `blank bootstrapServers is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Kafka(bootstrapServers = "  ", topic = "events")
+        }
+    }
+
+    @Test
+    fun `blank topic is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Kafka(bootstrapServers = "localhost:9092", topic = "")
+        }
+    }
+
+    @Test
+    fun `blank clientId is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Kafka(bootstrapServers = "localhost:9092", topic = "events", clientId = "  ")
+        }
+    }
+
+    @Test
+    fun `zero timeoutMillis is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Kafka(bootstrapServers = "localhost:9092", topic = "events", timeoutMillis = 0)
+        }
+    }
+
+    @Test
+    fun `negative timeoutMillis is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Kafka(bootstrapServers = "localhost:9092", topic = "events", timeoutMillis = -1)
+        }
+    }
+
+    @Test
+    fun `additionalProperties are preserved`() {
+        val props = mapOf("security.protocol" to "SASL_SSL", "sasl.mechanism" to "PLAIN")
+        val config = Kafka(bootstrapServers = "broker:9093", topic = "secure-events", additionalProperties = props)
+        assertEquals(props, config.additionalProperties)
+    }
+}

--- a/src/test/kotlin/io/github/aeshen/observability/config/sink/RedisConfigTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/config/sink/RedisConfigTest.kt
@@ -1,0 +1,58 @@
+package io.github.aeshen.observability.config.sink
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class RedisConfigTest {
+    @Test
+    fun `valid config constructs successfully`() {
+        val config = Redis(uri = "redis://localhost:6379", streamKey = "events")
+        assertEquals("redis://localhost:6379", config.uri)
+        assertEquals("events", config.streamKey)
+        assertNull(config.maxlen)
+        assertEquals(5_000L, config.timeoutMillis)
+    }
+
+    @Test
+    fun `maxlen can be specified`() {
+        val config = Redis(uri = "redis://localhost:6379", streamKey = "events", maxlen = 10_000)
+        assertEquals(10_000L, config.maxlen)
+    }
+
+    @Test
+    fun `blank uri is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Redis(uri = "  ", streamKey = "events")
+        }
+    }
+
+    @Test
+    fun `blank streamKey is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Redis(uri = "redis://localhost:6379", streamKey = "")
+        }
+    }
+
+    @Test
+    fun `zero timeoutMillis is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Redis(uri = "redis://localhost:6379", streamKey = "events", timeoutMillis = 0)
+        }
+    }
+
+    @Test
+    fun `zero maxlen is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Redis(uri = "redis://localhost:6379", streamKey = "events", maxlen = 0)
+        }
+    }
+
+    @Test
+    fun `negative maxlen is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Redis(uri = "redis://localhost:6379", streamKey = "events", maxlen = -1)
+        }
+    }
+}

--- a/src/test/kotlin/io/github/aeshen/observability/config/sink/S3ConfigTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/config/sink/S3ConfigTest.kt
@@ -1,0 +1,59 @@
+package io.github.aeshen.observability.config.sink
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class S3ConfigTest {
+    @Test
+    fun `valid config constructs successfully`() {
+        val config = S3(bucket = "my-bucket", region = "eu-west-1")
+        assertEquals("my-bucket", config.bucket)
+        assertEquals("eu-west-1", config.region)
+        assertEquals("observability/", config.keyPrefix)
+        assertNull(config.endpoint)
+        assertEquals(30_000L, config.timeoutMillis)
+    }
+
+    @Test
+    fun `custom endpoint is accepted`() {
+        val config = S3(bucket = "bucket", region = "us-east-1", endpoint = "http://localhost:9000")
+        assertEquals("http://localhost:9000", config.endpoint)
+    }
+
+    @Test
+    fun `blank bucket is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            S3(bucket = " ", region = "eu-west-1")
+        }
+    }
+
+    @Test
+    fun `blank region is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            S3(bucket = "my-bucket", region = "")
+        }
+    }
+
+    @Test
+    fun `blank keyPrefix is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            S3(bucket = "my-bucket", region = "eu-west-1", keyPrefix = "  ")
+        }
+    }
+
+    @Test
+    fun `zero timeoutMillis is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            S3(bucket = "my-bucket", region = "eu-west-1", timeoutMillis = 0)
+        }
+    }
+
+    @Test
+    fun `relative endpoint is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            S3(bucket = "my-bucket", region = "eu-west-1", endpoint = "not-a-uri")
+        }
+    }
+}

--- a/src/test/kotlin/io/github/aeshen/observability/config/sink/WebhookConfigTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/config/sink/WebhookConfigTest.kt
@@ -1,0 +1,63 @@
+package io.github.aeshen.observability.config.sink
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class WebhookConfigTest {
+    @Test
+    fun `valid config constructs successfully`() {
+        val config = Webhook(endpoint = "https://hooks.example.com/events", secret = "s3cr3t")
+        assertEquals("https://hooks.example.com/events", config.endpoint)
+        assertEquals("s3cr3t", config.secret)
+        assertEquals("X-Hub-Signature-256", config.signatureHeader)
+        assertEquals(emptyMap(), config.headers)
+        assertEquals(5_000L, config.timeoutMillis)
+    }
+
+    @Test
+    fun `blank endpoint is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Webhook(endpoint = "  ", secret = "s3cr3t")
+        }
+    }
+
+    @Test
+    fun `non-http endpoint scheme is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Webhook(endpoint = "ftp://example.com/hook", secret = "s3cr3t")
+        }
+    }
+
+    @Test
+    fun `blank secret is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Webhook(endpoint = "https://hooks.example.com/events", secret = "")
+        }
+    }
+
+    @Test
+    fun `blank signatureHeader is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Webhook(endpoint = "https://hooks.example.com/events", secret = "s3cr3t", signatureHeader = "  ")
+        }
+    }
+
+    @Test
+    fun `zero timeoutMillis is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Webhook(endpoint = "https://hooks.example.com/events", secret = "s3cr3t", timeoutMillis = 0)
+        }
+    }
+
+    @Test
+    fun `blank header key is rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            Webhook(
+                endpoint = "https://hooks.example.com/events",
+                secret = "s3cr3t",
+                headers = mapOf("" to "value"),
+            )
+        }
+    }
+}

--- a/src/test/kotlin/io/github/aeshen/observability/sink/impl/SinkImplementationsTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/sink/impl/SinkImplementationsTest.kt
@@ -7,6 +7,7 @@ import io.github.aeshen.observability.ObservabilityEvent
 import io.github.aeshen.observability.codec.EncodedEvent
 import io.github.aeshen.observability.config.sink.Http
 import io.github.aeshen.observability.config.sink.HttpMethod
+import io.github.aeshen.observability.config.sink.Webhook
 import io.github.aeshen.observability.key.LongKey
 import io.github.aeshen.observability.key.StringKey
 import io.github.aeshen.observability.sink.EventLevel
@@ -16,13 +17,20 @@ import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.logs.SdkLoggerProvider
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter
+import org.apache.kafka.clients.producer.MockProducer
+import org.apache.kafka.common.KafkaException
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.apache.kafka.common.serialization.StringSerializer
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.net.InetSocketAddress
 import java.nio.file.Files
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPInputStream
 import java.util.zip.ZipInputStream
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -312,6 +320,199 @@ class SinkImplementationsTest {
         assertFailsWith<IllegalStateException> {
             sink.close()
         }
+    }
+
+    @Test
+    fun `kafka sink sends encoded payload to correct topic with event name as key`() {
+        val mockProducer = MockProducer(true, StringSerializer(), ByteArraySerializer())
+        val sink = KafkaObservabilitySink(mockProducer, "my-topic", 5_000)
+
+        sink.handle(encoded("payload", mutableMapOf("event" to "order.created")))
+
+        assertEquals(1, mockProducer.history().size)
+        val record = mockProducer.history().single()
+        assertEquals("my-topic", record.topic())
+        assertEquals("order.created", record.key())
+        assertEquals("payload", record.value().toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `kafka sink falls back to default key when metadata has no event entry`() {
+        val mockProducer = MockProducer(true, StringSerializer(), ByteArraySerializer())
+        val sink = KafkaObservabilitySink(mockProducer, "my-topic", 5_000)
+
+        sink.handle(encoded("no-event-key"))
+
+        assertEquals("observability", mockProducer.history().single().key())
+    }
+
+    @Test
+    fun `kafka sink surfaces send failure as illegal state exception`() {
+        val mockProducer = MockProducer(false, StringSerializer(), ByteArraySerializer())
+        val sink = KafkaObservabilitySink(mockProducer, "my-topic", 5_000)
+
+        mockProducer.errorNext(KafkaException("broker unavailable"))
+
+        assertFailsWith<IllegalStateException> {
+            sink.handle(encoded("payload"))
+        }
+    }
+
+    @Test
+    fun `kafka sink sends multiple events in order`() {
+        val mockProducer = MockProducer(true, StringSerializer(), ByteArraySerializer())
+        val sink = KafkaObservabilitySink(mockProducer, "events", 5_000)
+
+        sink.handle(encoded("first", mutableMapOf("event" to "evt.a")))
+        sink.handle(encoded("second", mutableMapOf("event" to "evt.b")))
+
+        val history = mockProducer.history()
+        assertEquals(2, history.size)
+        assertEquals("first", history[0].value().toString(Charsets.UTF_8))
+        assertEquals("second", history[1].value().toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `webhook sink posts payload with hmac signature header`() {
+        val secret = "my-secret"
+        val requests = LinkedBlockingQueue<CapturedHttpRequest>()
+        val server =
+            HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+                createContext("/hook") { exchange ->
+                    requests.offer(
+                        CapturedHttpRequest(
+                            method = exchange.requestMethod,
+                            path = exchange.requestURI.path,
+                            contentType = exchange.requestHeaders.getFirst("Content-Type"),
+                            body = exchange.requestBody.use { it.readBytes() },
+                        ),
+                    )
+                    exchange.sendResponseHeaders(204, -1)
+                    exchange.close()
+                }
+                start()
+            }
+
+        try {
+            val config =
+                Webhook(
+                    endpoint = "http://127.0.0.1:${server.address.port}/hook",
+                    secret = secret,
+                    headers = mapOf("Content-Type" to "application/json"),
+                )
+            val sink = WebhookObservabilitySink(config)
+            val payload = "{\"event\":\"test\"}\n".toByteArray()
+            sink.handle(encoded("{\"event\":\"test\"}\n"))
+
+            val captured = requests.poll(5, TimeUnit.SECONDS)
+            assertNotNull(captured)
+            assertEquals("POST", captured.method)
+
+            val mac = Mac.getInstance("HmacSHA256")
+            mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+            val expectedSig = "sha256=" + mac.doFinal(payload).joinToString("") { "%02x".format(it) }
+
+            // Verify the captured request body matches what was signed
+            assertEquals(expectedSig, hmacHeader(captured.body, secret))
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `webhook sink throws on non-success response`() {
+        val server =
+            HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+                createContext("/hook") { exchange ->
+                    exchange.requestBody.use { it.readBytes() }
+                    exchange.sendResponseHeaders(400, -1)
+                    exchange.close()
+                }
+                start()
+            }
+
+        try {
+            val sink =
+                WebhookObservabilitySink(
+                    Webhook(
+                        endpoint = "http://127.0.0.1:${server.address.port}/hook",
+                        secret = "s",
+                    ),
+                )
+            val error = assertFailsWith<IllegalStateException> { sink.handle(encoded("body")) }
+            assertTrue(error.message.orEmpty().contains("status=400"))
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `s3 sink uploads single event as gzipped jsonl`() {
+        val uploads = mutableListOf<Pair<String, ByteArray>>()
+        val sink = S3ObservabilitySink(S3Uploader { key, bytes -> uploads += key to bytes }, "logs/")
+
+        sink.handle(encoded("{\"name\":\"test\"}\n"))
+
+        assertEquals(1, uploads.size)
+        val (key, bytes) = uploads.single()
+        assertTrue(key.startsWith("logs/"))
+        assertTrue(key.endsWith(".jsonl.gz"))
+        val decompressed = GZIPInputStream(bytes.inputStream()).readBytes().toString(Charsets.UTF_8)
+        assertTrue(decompressed.contains("{\"name\":\"test\"}"))
+    }
+
+    @Test
+    fun `s3 sink uploads batch as single gzipped file`() {
+        val uploads = mutableListOf<Pair<String, ByteArray>>()
+        val sink = S3ObservabilitySink(S3Uploader { key, bytes -> uploads += key to bytes }, "obs/")
+
+        sink.handleBatch(listOf(encoded("first\n"), encoded("second\n")))
+
+        assertEquals(1, uploads.size)
+        val decompressed = GZIPInputStream(uploads.single().second.inputStream()).readBytes().toString(Charsets.UTF_8)
+        assertTrue(decompressed.contains("first"))
+        assertTrue(decompressed.contains("second"))
+    }
+
+    @Test
+    fun `s3 sink ignores empty batch`() {
+        val uploads = mutableListOf<Pair<String, ByteArray>>()
+        val sink = S3ObservabilitySink(S3Uploader { key, bytes -> uploads += key to bytes }, "obs/")
+
+        sink.handleBatch(emptyList())
+
+        assertEquals(0, uploads.size)
+    }
+
+    @Test
+    fun `redis sink publishes event with event name and payload`() {
+        val published = mutableListOf<Pair<String, String>>()
+        val sink = RedisObservabilitySink(RedisPublisher { eventName, payload -> published += eventName to payload })
+
+        sink.handle(encoded("{\"x\":1}\n", mutableMapOf("event" to "order.placed")))
+
+        assertEquals(1, published.size)
+        assertEquals("order.placed", published.single().first)
+        assertEquals("{\"x\":1}\n", published.single().second)
+    }
+
+    @Test
+    fun `redis sink falls back to default key when no event in metadata`() {
+        val published = mutableListOf<Pair<String, String>>()
+        val sink = RedisObservabilitySink(RedisPublisher { eventName, payload -> published += eventName to payload })
+
+        sink.handle(encoded("payload"))
+
+        assertEquals("observability", published.single().first)
+    }
+
+    private fun hmacHeader(
+        body: ByteArray,
+        secret: String,
+    ): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+        return "sha256=" + mac.doFinal(body).joinToString("") { "%02x".format(it) }
     }
 
     private fun encoded(

--- a/src/test/kotlin/io/github/aeshen/observability/sink/registry/SinkRegistryTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/sink/registry/SinkRegistryTest.kt
@@ -3,7 +3,11 @@ package io.github.aeshen.observability.sink.registry
 import io.github.aeshen.observability.codec.EncodedEvent
 import io.github.aeshen.observability.config.sink.Console
 import io.github.aeshen.observability.config.sink.Http
+import io.github.aeshen.observability.config.sink.Kafka
+import io.github.aeshen.observability.config.sink.Redis
+import io.github.aeshen.observability.config.sink.S3
 import io.github.aeshen.observability.config.sink.SinkConfig
+import io.github.aeshen.observability.config.sink.Webhook
 import io.github.aeshen.observability.sink.ObservabilitySink
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -60,5 +64,33 @@ class SinkRegistryTest {
 
         assertNotNull(registry.resolve(Console))
         assertNotNull(registry.resolve(CustomSinkConfig("https://partner.example/logs")))
+    }
+
+    @Test
+    fun `default registry resolves kafka sink`() {
+        val resolved = SinkRegistry.default().resolve(Kafka(bootstrapServers = "localhost:9092", topic = "events"))
+        assertNotNull(resolved)
+        resolved.close()
+    }
+
+    @Test
+    fun `default registry resolves webhook sink`() {
+        val resolved = SinkRegistry.default().resolve(Webhook(endpoint = "https://hooks.example.com/e", secret = "s"))
+        assertNotNull(resolved)
+    }
+
+    @Test
+    fun `default registry resolves s3 sink`() {
+        val resolved = SinkRegistry.default().resolve(S3(bucket = "my-bucket", region = "eu-west-1"))
+        assertNotNull(resolved)
+        resolved.close()
+    }
+
+    @Test
+    fun `default registry resolves redis sink`() {
+        // fromConfig uses connectAsync — construction succeeds without a real Redis server
+        val resolved = SinkRegistry.default().resolve(Redis(uri = "redis://localhost:6379", streamKey = "events"))
+        assertNotNull(resolved)
+        resolved.close()
     }
 }


### PR DESCRIPTION
## What changed

Expands the built-in sink ecosystem with four new production-ready sinks, all following the established pattern: config data class, internal impl, BuiltInSinkProvider registration, and tests requiring no real infrastructure.

Kafka
- Produces encoded events as ProducerRecord<String, ByteArray> to a topic
- Key derived from event metadata ("event"), falls back to "observability"
- SASL/SSL and other producer settings via additionalProperties
- Tested with MockProducer (no broker needed)
- Optional dep: org.apache.kafka:kafka-clients

Webhook
- HTTP POST with HMAC-SHA256 request signing (sha256=<hex>)
- Configurable signature header (default: X-Hub-Signature-256)
- No new runtime dependency — uses JDK javax.crypto.Mac
- Tested with embedded HttpServer

S3
- Implements BatchCapableObservabilitySink
- Uploads gzip-compressed JSONL with time-partitioned keys ({prefix}/{yyyy/MM/dd/HH}/{uuid}.jsonl.gz)
- Custom endpoint support for MinIO and Cloudflare R2
- Tested via S3Uploader fun interface
- Optional dep: software.amazon.awssdk:s3

Redis Streams
- Publishes events via XADD with optional approximate MAXLEN trimming
- Lazy connection: construction never blocks if Redis is unreachable
- Timeout applied via RedisURI before client creation
- Connection and XADD errors consistently wrapped as IllegalStateException
- Tested via RedisPublisher fun interface
- Optional dep: io.lettuce:lettuce-core

closes #11 

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [x] Built-in sinks / sink decorators (`Console`, `File`, `ZipFile`, `OpenTelemetry`, `Http`)
- [ ] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [ ] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`)
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [ ] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [ ] Added/updated tests
- [x] Ran `./gradlew test`
- [ ] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew ktlintCheck`
- [x] Ran `./gradlew detekt`
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [ ] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [ ] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [ ] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [x] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [x] Updated `CHANGELOG.md` (if needed)
- [ ] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
