### PR TITLE
feat(benchmarks): expand benchmark coverage and publish comparative results

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,18 @@
+# Observability
+
+This context defines the benchmark language used to describe repeatable performance scenarios and their documented comparison outputs.
+
+## Language
+
+**Benchmark Scenario**:
+A named workload configuration used to compare observability runtime behavior under a specific sink or decorator pattern.
+_Avoid_: One-off run, ad hoc test
+
+**Comparative Result**:
+A documented side-by-side benchmark outcome that helps readers compare scenarios, while explicitly remaining illustrative rather than a hard performance guarantee.
+_Avoid_: Guarantee, SLA
+
+## Example dialogue
+
+Dev: "Is a benchmark scenario the same thing as a published result?"
+Domain expert: "No. The scenario is the workload definition; the comparative result is the documented example output readers use to interpret the suite."

--- a/README.md
+++ b/README.md
@@ -1336,13 +1336,19 @@ The suite verifies event forwarding, close idempotency, concurrent handle safety
 
 ## Benchmarks
 
-The `benchmarks` module provides a lightweight load/backpressure harness for sink decorators:
+The `benchmarks` module provides a lightweight comparative harness for direct, async, batching, retry, and backpressure scenarios:
 
 ```bash
 ./gradlew :benchmarks:run
 ```
 
-Prints elapsed time and events/second for direct vs. async sink configurations.
+You can also run a subset of scenarios:
+
+```bash
+./gradlew :benchmarks:run --args "async-noop-cap-2048 retry-once-every-5th"
+```
+
+The benchmark guide with scenario descriptions, output interpretation notes, and example comparative results lives in [`benchmarks/README.md`](./benchmarks/README.md).
 
 ---
 
@@ -1391,7 +1397,7 @@ To auto-format Kotlin sources:
 |-----------------------------------------|----------------------------------------------------------------------|
 | `:` (root)                              | Core library — pipeline, sinks, codec, encryption, decorators        |
 | `:query-spi`                            | Optional: backend-agnostic audit record query SPI                    |
-| `:benchmarks`                           | Load/backpressure harness for sink decorator performance             |
+| `:benchmarks`                           | Comparative performance and backpressure harness                     |
 | `:examples:third-party-sink-example`    | Example custom sink module with SPI wiring and conformance tests     |
 
 ---

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,12 +1,90 @@
 # Benchmarks
 
-This module provides a lightweight load/backpressure harness for sink decorators.
+This module provides a lightweight comparative benchmark harness for the observability sink decorators and representative in-process sink behaviors.
 
-## Run
+It is designed for:
+
+- relative trend comparison between scenarios
+- backpressure visibility
+- decorator trade-off exploration during development and release prep
+
+It is **not** intended to be a universal performance claim for all JVMs, workloads, or deployment environments.
+
+## What the suite covers
+
+The current scenario set includes:
+
+| Scenario | Purpose |
+| --- | --- |
+| `direct-noop` | direct baseline with minimal sink overhead |
+| `async-noop-cap-128` | async overhead with a small queue |
+| `async-noop-cap-2048` | async overhead with a larger queue |
+| `direct-delay-250us` | representative direct sink behavior with deterministic per-event cost |
+| `async-backpressure-queue-32` | async backpressure under queue saturation and drop pressure |
+| `batching-delay-direct` | batching over a delegate that still pays per-event cost |
+| `batching-delay-batch-capable` | batching over a batch-capable delegate that pays once per batch |
+| `retry-once-every-5th` | retry path overhead when intermittent failures succeed on retry |
+
+## Run all scenarios
 
 ```bash
 ./gradlew :benchmarks:run
 ```
 
-The runner prints elapsed time and events/second for direct vs async sink configurations.
+## Run selected scenarios
 
+The runner executes every scenario by default, but you can filter by name with Gradle's `--args`:
+
+```bash
+./gradlew :benchmarks:run --args "async-noop-cap-2048"
+./gradlew :benchmarks:run --args "async-noop-cap-2048 retry-once-every-5th"
+./gradlew :benchmarks:run --args "async-noop-cap-2048,retry-once-every-5th"
+```
+
+## What the report means
+
+The runner prints a single row per scenario with:
+
+- `producerMs` / `producerEvS`: enqueue or direct handle cost before close and drain
+- `endToEndMs` / `endToEndEvS`: full run including close and drain
+- `avgProducerUs` / `avgEndUs`: coarse averages derived from total elapsed time, not per-event timers
+- `drops` / `queueMax`: async backpressure signals from `InMemoryOperationalDiagnostics`
+- `batchAvgMs`: average batch flush time from diagnostics
+- `retryExh`: retry exhaustion count from diagnostics
+
+Important interpretation notes:
+
+- every scenario performs a warmup pass before measured output
+- retry scenarios inject zero-cost backoff so they measure decorator overhead, not `Thread.sleep`
+- async scenarios can show a large gap between producer-side and end-to-end numbers
+- sub-millisecond batch flushes may display as `0.00` because diagnostics record elapsed time in whole milliseconds
+
+## Example comparative results
+
+Example output from a local run of this suite:
+
+| Scenario | Events | producerMs | endToEndMs | producerEvS | endToEndEvS | drops | queueMax |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `direct-noop` | 100000 | 49.66 | 49.67 | 2013804.63 | 2013375.50 | 0 | 0 |
+| `async-noop-cap-128` | 100000 | 70.03 | 175.20 | 1427981.53 | 570785.21 | 0 | 128 |
+| `async-noop-cap-2048` | 100000 | 39.83 | 141.22 | 2510557.46 | 708116.05 | 0 | 855 |
+| `direct-delay-250us` | 5000 | 1252.51 | 1252.54 | 3991.97 | 3991.90 | 0 | 0 |
+| `async-backpressure-queue-32` | 5000 | 1.11 | 17.20 | 4497078.25 | 290768.12 | 4966 | 32 |
+| `batching-delay-direct` | 5000 | 1255.46 | 1255.54 | 3982.61 | 3982.36 | 0 | 0 |
+| `batching-delay-batch-capable` | 5000 | 26.26 | 26.31 | 190375.26 | 190039.70 | 0 | 0 |
+| `retry-once-every-5th` | 25000 | 8.30 | 8.31 | 3011322.57 | 3008966.72 | 0 | 0 |
+
+## What the results do **not** represent
+
+Do not treat these numbers as:
+
+- guarantees for production systems
+- cross-machine performance constants
+- a substitute for measuring your own sink, payload size, and workload mix
+
+The most useful reading is comparative:
+
+- how much overhead a decorator introduces relative to a direct baseline
+- whether batching helps only when the delegate is batch-capable
+- how small async queues behave under stress
+- how retry bookkeeping changes throughput even when backoff sleeps are removed

--- a/benchmarks/api/benchmarks.api
+++ b/benchmarks/api/benchmarks.api
@@ -1,5 +1,5 @@
 public final class io/github/aeshen/observability/benchmarks/SinkBackpressureBenchmarkKt {
 	public static final fun main ()V
-	public static synthetic fun main ([Ljava/lang/String;)V
+	public static final fun main ([Ljava/lang/String;)V
 }
 

--- a/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/BenchmarkFixtures.kt
+++ b/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/BenchmarkFixtures.kt
@@ -1,0 +1,77 @@
+package io.github.aeshen.observability.benchmarks
+
+import io.github.aeshen.observability.EventName
+import io.github.aeshen.observability.ObservabilityContext
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.event
+import io.github.aeshen.observability.sink.BatchCapableObservabilitySink
+import io.github.aeshen.observability.sink.EventLevel
+import io.github.aeshen.observability.sink.ObservabilitySink
+
+private const val BENCHMARK_EVENT_NAME = "sink.backpressure.bench"
+private const val SEQUENCE_METADATA_KEY = "sequence"
+
+internal fun sampleEvent(sequence: Int): EncodedEvent =
+    EncodedEvent(
+        original =
+            event(BenchmarkEvent.BENCH) {
+                level(EventLevel.INFO)
+                context(ObservabilityContext.empty())
+            },
+        encoded = "event-$sequence".toByteArray(Charsets.UTF_8),
+        metadata = mutableMapOf(SEQUENCE_METADATA_KEY to sequence),
+    )
+
+private fun spinDelay(delayNanos: Long) {
+    if (delayNanos <= 0L) return
+
+    val startedAt = System.nanoTime()
+    while (System.nanoTime() - startedAt < delayNanos) {
+        Thread.onSpinWait()
+    }
+}
+
+internal class NoopSink : ObservabilitySink {
+    override fun handle(event: EncodedEvent) = Unit
+}
+
+internal open class FixedDelaySink(
+    private val delayNanos: Long,
+) : ObservabilitySink {
+    override fun handle(event: EncodedEvent) {
+        spinDelay(delayNanos)
+    }
+}
+
+internal class BatchCapableDelaySink(
+    delayNanos: Long,
+) : FixedDelaySink(delayNanos), BatchCapableObservabilitySink {
+    private val batchDelayNanos = delayNanos
+
+    override fun handleBatch(events: List<EncodedEvent>) {
+        spinDelay(batchDelayNanos)
+    }
+}
+
+internal class FailOnceEveryNthEventSink(
+    private val failEvery: Int,
+) : ObservabilitySink {
+    private val failedSequences = mutableSetOf<Int>()
+
+    override fun handle(event: EncodedEvent) {
+        val sequence = event.metadata[SEQUENCE_METADATA_KEY] as? Int ?: return
+        if (sequence == 0 || sequence % failEvery != 0) {
+            return
+        }
+
+        if (failedSequences.add(sequence)) {
+            error("Synthetic retry trigger for sequence=$sequence")
+        }
+    }
+}
+
+private enum class BenchmarkEvent(
+    override val eventName: String? = null,
+) : EventName {
+    BENCH(BENCHMARK_EVENT_NAME),
+}

--- a/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/BenchmarkModels.kt
+++ b/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/BenchmarkModels.kt
@@ -1,0 +1,30 @@
+package io.github.aeshen.observability.benchmarks
+
+import io.github.aeshen.observability.diagnostics.InMemoryOperationalDiagnostics
+import io.github.aeshen.observability.diagnostics.OperationalMetricsSnapshot
+import io.github.aeshen.observability.sink.ObservabilitySink
+
+internal const val DEFAULT_WARMUP_EVENTS = 1_000
+
+internal data class BenchmarkScenario(
+    val name: String,
+    val category: String,
+    val description: String,
+    val eventCount: Int,
+    val warmupEventCount: Int = minOf(eventCount, DEFAULT_WARMUP_EVENTS),
+    val buildSink: (InMemoryOperationalDiagnostics) -> ObservabilitySink,
+)
+
+internal data class BenchmarkResult(
+    val name: String,
+    val eventCount: Int,
+    val producerElapsedNanos: Long,
+    val endToEndElapsedNanos: Long,
+    val metrics: OperationalMetricsSnapshot,
+)
+
+internal data class ScenarioExecution(
+    val sink: ObservabilitySink,
+    val diagnostics: InMemoryOperationalDiagnostics,
+    val producerFinishedAt: Long,
+)

--- a/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/BenchmarkReport.kt
+++ b/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/BenchmarkReport.kt
@@ -1,0 +1,87 @@
+package io.github.aeshen.observability.benchmarks
+
+import java.util.Locale
+
+private const val MILLIS_PER_SECOND = 1000.0
+private const val NANOS_PER_MILLI = 1_000_000.0
+private const val NANOS_PER_MICRO = 1_000.0
+private const val TABLE_RULE_LENGTH = 173
+
+private const val SCENARIO_WIDTH = 28
+private const val EVENTS_WIDTH = 7
+private const val PRODUCER_MS_WIDTH = 12
+private const val END_TO_END_MS_WIDTH = 12
+private const val PRODUCER_EVS_WIDTH = 14
+private const val END_TO_END_EVS_WIDTH = 14
+private const val AVG_PRODUCER_US_WIDTH = 15
+private const val AVG_END_US_WIDTH = 12
+private const val DROPS_WIDTH = 8
+private const val QUEUE_MAX_WIDTH = 9
+private const val BATCH_AVG_MS_WIDTH = 12
+private const val RETRY_EXHAUSTIONS_WIDTH = 10
+private const val DEFAULT_DECIMALS = 2
+
+internal fun printScenarioSummary(scenarios: List<BenchmarkScenario>) {
+    println("Scenarios:")
+    scenarios.forEach { scenario ->
+        println("- ${scenario.name} [${scenario.category}] — ${scenario.description}")
+    }
+}
+
+internal fun printTableHeader() {
+    println(
+        listOf(
+            "scenario".padEnd(SCENARIO_WIDTH),
+            "events".padStart(EVENTS_WIDTH),
+            "producerMs".padStart(PRODUCER_MS_WIDTH),
+            "endToEndMs".padStart(END_TO_END_MS_WIDTH),
+            "producerEvS".padStart(PRODUCER_EVS_WIDTH),
+            "endToEndEvS".padStart(END_TO_END_EVS_WIDTH),
+            "avgProducerUs".padStart(AVG_PRODUCER_US_WIDTH),
+            "avgEndUs".padStart(AVG_END_US_WIDTH),
+            "drops".padStart(DROPS_WIDTH),
+            "queueMax".padStart(QUEUE_MAX_WIDTH),
+            "batchAvgMs".padStart(BATCH_AVG_MS_WIDTH),
+            "retryExh".padStart(RETRY_EXHAUSTIONS_WIDTH),
+        ).joinToString(" | "),
+    )
+    println("-".repeat(TABLE_RULE_LENGTH))
+}
+
+internal fun printScenarioRow(result: BenchmarkResult) {
+    val producerMillis = result.producerElapsedNanos / NANOS_PER_MILLI
+    val endToEndMillis = result.endToEndElapsedNanos / NANOS_PER_MILLI
+    val producerThroughput = throughput(result.eventCount, producerMillis)
+    val endToEndThroughput = throughput(result.eventCount, endToEndMillis)
+    val averageProducerMicros = averageMicros(result.producerElapsedNanos, result.eventCount)
+    val averageEndToEndMicros = averageMicros(result.endToEndElapsedNanos, result.eventCount)
+
+    println(
+        listOf(
+            result.name.padEnd(SCENARIO_WIDTH),
+            result.eventCount.toString().padStart(EVENTS_WIDTH),
+            formatDecimal(producerMillis).padStart(PRODUCER_MS_WIDTH),
+            formatDecimal(endToEndMillis).padStart(END_TO_END_MS_WIDTH),
+            formatDecimal(producerThroughput).padStart(PRODUCER_EVS_WIDTH),
+            formatDecimal(endToEndThroughput).padStart(END_TO_END_EVS_WIDTH),
+            formatDecimal(averageProducerMicros).padStart(AVG_PRODUCER_US_WIDTH),
+            formatDecimal(averageEndToEndMicros).padStart(AVG_END_US_WIDTH),
+            result.metrics.asyncDrops.toString().padStart(DROPS_WIDTH),
+            result.metrics.asyncQueueDepthMax.toString().padStart(QUEUE_MAX_WIDTH),
+            formatDecimal(result.metrics.averageBatchFlushMillis).padStart(BATCH_AVG_MS_WIDTH),
+            result.metrics.retryExhaustions.toString().padStart(RETRY_EXHAUSTIONS_WIDTH),
+        ).joinToString(" | "),
+    )
+}
+
+private fun throughput(
+    eventCount: Int,
+    elapsedMillis: Double,
+): Double = eventCount.toDouble() / elapsedMillis.coerceAtLeast(1.0) * MILLIS_PER_SECOND
+
+private fun averageMicros(
+    elapsedNanos: Long,
+    eventCount: Int,
+): Double = elapsedNanos.toDouble() / eventCount.toDouble().coerceAtLeast(1.0) / NANOS_PER_MICRO
+
+private fun formatDecimal(value: Double): String = String.format(Locale.US, "%.${DEFAULT_DECIMALS}f", value)

--- a/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/BenchmarkRunner.kt
+++ b/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/BenchmarkRunner.kt
@@ -1,0 +1,49 @@
+package io.github.aeshen.observability.benchmarks
+
+import io.github.aeshen.observability.diagnostics.InMemoryOperationalDiagnostics
+
+internal fun warmupScenario(scenario: BenchmarkScenario) {
+    executeScenario(
+        scenario = scenario,
+        eventCount = scenario.warmupEventCount,
+    ).sink.close()
+}
+
+internal fun runScenario(scenario: BenchmarkScenario): BenchmarkResult {
+    val startedAt = System.nanoTime()
+    val execution =
+        executeScenario(
+            scenario = scenario,
+            eventCount = scenario.eventCount,
+        )
+    val producerElapsedNanos = execution.producerFinishedAt - startedAt
+
+    execution.sink.close()
+    val completedAt = System.nanoTime()
+
+    return BenchmarkResult(
+        name = scenario.name,
+        eventCount = scenario.eventCount,
+        producerElapsedNanos = producerElapsedNanos,
+        endToEndElapsedNanos = completedAt - startedAt,
+        metrics = execution.diagnostics.metricsSnapshot(),
+    )
+}
+
+private fun executeScenario(
+    scenario: BenchmarkScenario,
+    eventCount: Int,
+): ScenarioExecution {
+    val diagnostics = InMemoryOperationalDiagnostics()
+    val sink = scenario.buildSink(diagnostics)
+
+    repeat(eventCount) { sequence ->
+        sink.handle(sampleEvent(sequence))
+    }
+
+    return ScenarioExecution(
+        sink = sink,
+        diagnostics = diagnostics,
+        producerFinishedAt = System.nanoTime(),
+    )
+}

--- a/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/BenchmarkScenarios.kt
+++ b/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/BenchmarkScenarios.kt
@@ -1,0 +1,159 @@
+package io.github.aeshen.observability.benchmarks
+
+import io.github.aeshen.observability.diagnostics.InMemoryOperationalDiagnostics
+import io.github.aeshen.observability.sink.decorator.AsyncObservabilitySink
+import io.github.aeshen.observability.sink.decorator.BatchingObservabilitySink
+import io.github.aeshen.observability.sink.decorator.RetryingObservabilitySink
+
+private const val SMALL_DELAY_NANOS = 250_000L
+private const val BACKPRESSURE_DELAY_NANOS = 500_000L
+private const val FAIL_EVERY_FIFTH_EVENT = 5
+private const val DIRECT_EVENT_COUNT = 100_000
+private const val REPRESENTATIVE_EVENT_COUNT = 5_000
+private const val RETRY_EVENT_COUNT = 25_000
+private const val SMALL_ASYNC_CAPACITY = 128
+private const val LARGE_ASYNC_CAPACITY = 2048
+private const val STRESS_ASYNC_CAPACITY = 32
+private const val BATCH_SIZE = 50
+private const val BATCH_FLUSH_INTERVAL_MILLIS = 25L
+
+internal fun benchmarkScenarios(): List<BenchmarkScenario> =
+    buildList {
+        add(directNoopScenario())
+        add(asyncNoopScenario("async-noop-cap-128", SMALL_ASYNC_CAPACITY))
+        add(asyncNoopScenario("async-noop-cap-2048", LARGE_ASYNC_CAPACITY))
+        add(directDelayScenario())
+        add(asyncBackpressureScenario())
+        add(batchingDirectDelayScenario())
+        add(batchingBatchCapableScenario())
+        add(retryScenario())
+    }
+
+internal fun filterScenarios(
+    scenarios: List<BenchmarkScenario>,
+    rawArgs: List<String>,
+): List<BenchmarkScenario> {
+    val filters =
+        rawArgs
+            .flatMap { arg -> arg.split(',') }
+            .map { token -> token.trim() }
+            .filter { token -> token.isNotEmpty() }
+
+    if (filters.isEmpty()) {
+        return scenarios
+    }
+
+    val byName = scenarios.associateBy(BenchmarkScenario::name)
+    val missing = filters.filterNot(byName::containsKey)
+    require(missing.isEmpty()) {
+        buildString {
+            append("Unknown benchmark scenario(s): ")
+            append(missing.joinToString(", "))
+            append(". Available scenarios: ")
+            append(scenarios.joinToString(", ", transform = BenchmarkScenario::name))
+        }
+    }
+
+    return filters.mapNotNull(byName::get)
+}
+
+private fun directNoopScenario() =
+    BenchmarkScenario(
+        name = "direct-noop",
+        category = "direct",
+        description = "Baseline direct throughput against a noop sink.",
+        eventCount = DIRECT_EVENT_COUNT,
+        buildSink = { NoopSink() },
+    )
+
+private fun asyncNoopScenario(
+    name: String,
+    capacity: Int,
+) = BenchmarkScenario(
+    name = name,
+    category = "async",
+    description = "Async decorator over a noop sink with capacity=$capacity.",
+    eventCount = DIRECT_EVENT_COUNT,
+    buildSink = { diagnostics: InMemoryOperationalDiagnostics ->
+        AsyncObservabilitySink(
+            delegate = NoopSink(),
+            capacity = capacity,
+            failOnDrop = true,
+            diagnostics = diagnostics,
+        )
+    },
+)
+
+private fun directDelayScenario() =
+    BenchmarkScenario(
+        name = "direct-delay-250us",
+        category = "sink-behavior",
+        description = "Direct delivery to a deterministic in-process delayed sink.",
+        eventCount = REPRESENTATIVE_EVENT_COUNT,
+        buildSink = { FixedDelaySink(SMALL_DELAY_NANOS) },
+    )
+
+private fun asyncBackpressureScenario() =
+    BenchmarkScenario(
+        name = "async-backpressure-queue-32",
+        category = "backpressure",
+        description = "Async queue stress over a slower sink to surface drops and queue saturation.",
+        eventCount = REPRESENTATIVE_EVENT_COUNT,
+        buildSink = { diagnostics: InMemoryOperationalDiagnostics ->
+            AsyncObservabilitySink(
+                delegate = FixedDelaySink(BACKPRESSURE_DELAY_NANOS),
+                capacity = STRESS_ASYNC_CAPACITY,
+                offerTimeoutMillis = 0,
+                failOnDrop = false,
+                diagnostics = diagnostics,
+            )
+        },
+    )
+
+private fun batchingDirectDelayScenario() =
+    BenchmarkScenario(
+        name = "batching-delay-direct",
+        category = "batching",
+        description = "Batching over a delegate that still pays delay per event.",
+        eventCount = REPRESENTATIVE_EVENT_COUNT,
+        buildSink = { diagnostics: InMemoryOperationalDiagnostics ->
+            BatchingObservabilitySink(
+                delegate = FixedDelaySink(SMALL_DELAY_NANOS),
+                maxBatchSize = BATCH_SIZE,
+                flushIntervalMillis = BATCH_FLUSH_INTERVAL_MILLIS,
+                diagnostics = diagnostics,
+            )
+        },
+    )
+
+private fun batchingBatchCapableScenario() =
+    BenchmarkScenario(
+        name = "batching-delay-batch-capable",
+        category = "batching",
+        description = "Batching over a batch-capable delegate that pays delay once per batch.",
+        eventCount = REPRESENTATIVE_EVENT_COUNT,
+        buildSink = { diagnostics: InMemoryOperationalDiagnostics ->
+            BatchingObservabilitySink(
+                delegate = BatchCapableDelaySink(SMALL_DELAY_NANOS),
+                maxBatchSize = BATCH_SIZE,
+                flushIntervalMillis = BATCH_FLUSH_INTERVAL_MILLIS,
+                diagnostics = diagnostics,
+            )
+        },
+    )
+
+private fun retryScenario() =
+    BenchmarkScenario(
+        name = "retry-once-every-5th",
+        category = "retry",
+        description = "Retry decorator where every fifth event fails once, then succeeds on retry.",
+        eventCount = RETRY_EVENT_COUNT,
+        buildSink = { diagnostics: InMemoryOperationalDiagnostics ->
+            RetryingObservabilitySink(
+                delegate = FailOnceEveryNthEventSink(FAIL_EVERY_FIFTH_EVENT),
+                maxAttempts = 3,
+                sleep = {},
+                diagnostics = diagnostics,
+            )
+        },
+    )

--- a/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/SinkBackpressureBenchmark.kt
+++ b/benchmarks/src/main/kotlin/io/github/aeshen/observability/benchmarks/SinkBackpressureBenchmark.kt
@@ -1,59 +1,35 @@
 package io.github.aeshen.observability.benchmarks
 
-import io.github.aeshen.observability.EventName
-import io.github.aeshen.observability.ObservabilityContext
-import io.github.aeshen.observability.codec.EncodedEvent
-import io.github.aeshen.observability.event
-import io.github.aeshen.observability.sink.EventLevel
-import io.github.aeshen.observability.sink.ObservabilitySink
-import io.github.aeshen.observability.sink.decorator.AsyncObservabilitySink
-import kotlin.system.measureTimeMillis
+fun main() = main(emptyArray())
 
-private const val EVENT_COUNT = 100_000
-private const val MILLIS_PER_SECOND = 1000.0
+fun main(args: Array<String>) {
+    val scenarios = benchmarkScenarios()
+    val selected = filterScenarios(scenarios, args.toList())
 
-fun main() {
-    val scenarios =
-        listOf(
-            "direct" to NoopSink(),
-            "async-cap-128" to AsyncObservabilitySink(delegate = NoopSink(), capacity = 128, failOnDrop = true),
-            "async-cap-2048" to AsyncObservabilitySink(delegate = NoopSink(), capacity = 2048, failOnDrop = true),
-        )
-
-    println("Running backpressure benchmark with $EVENT_COUNT events")
-    for ((name, sink) in scenarios) {
-        val elapsedMs =
-            measureTimeMillis {
-                sink.use {
-                    repeat(EVENT_COUNT) { idx ->
-                        it.handle(sampleEvent("event-$idx"))
-                    }
-                }
-            }
-
-        val throughput = EVENT_COUNT.toDouble() / elapsedMs.toDouble().coerceAtLeast(1.0) * MILLIS_PER_SECOND
-        println("$name: elapsed=${elapsedMs}ms throughput=${"%.2f".format(throughput)} events/s")
+    println("Running ${selected.size} benchmark scenario(s)")
+    if (args.isNotEmpty()) {
+        println("Scenario filter: ${args.joinToString(", ")}")
     }
-}
-
-private class NoopSink : ObservabilitySink {
-    override fun handle(event: EncodedEvent) {
-        // intentional no-op sink for throughput measurement
-    }
-}
-
-private fun sampleEvent(payload: String): EncodedEvent =
-    EncodedEvent(
-        original =
-            event(BenchmarkEvent.BENCH) {
-                level(EventLevel.INFO)
-                context(ObservabilityContext.empty())
-            },
-        encoded = payload.toByteArray(Charsets.UTF_8),
+    println()
+    println(
+        "Each scenario performs a warmup pass first. " +
+            "Retry benchmarks inject zero-cost backoff to isolate decorator overhead.",
     )
+    println()
 
-private enum class BenchmarkEvent(
-    override val eventName: String? = null,
-) : EventName {
-    BENCH("sink.backpressure.bench"),
+    printScenarioSummary(selected)
+    println()
+    printTableHeader()
+
+    selected.forEach { scenario ->
+        warmupScenario(scenario)
+        val result = runScenario(scenario)
+        printScenarioRow(result)
+    }
+
+    println()
+    println("Legend:")
+    println("- producerMs / producerEvS: enqueue or direct handle cost before close/drain")
+    println("- endToEndMs / endToEndEvS: full run including close and drain")
+    println("- avg*Us values are coarse averages derived from total elapsed time, not per-event timers")
 }


### PR DESCRIPTION
## What changed

Replace the single hardcoded benchmark runner with a scenario-driven harness
that covers direct, async, batching, retry, and backpressure behavior using
deterministic in-process sink fixtures.

Add warmup passes before measured runs, zero-cost retry backoff injection for
retry-overhead measurement, producer-side vs end-to-end timing, and CLI
scenario filtering via :benchmarks:run --args.

Expand benchmark documentation with scenario descriptions, run commands,
filtering examples, interpretation caveats, and example comparative results.
Update the root README benchmark section and refresh the benchmark API dump.

Closing #12

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [ ] Built-in sinks / decorators / providers
- [ ] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [x] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`)
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [ ] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [ ] Added/updated tests
- [ ] Ran `./gradlew test`
- [ ] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [ ] Ran `./gradlew apiCheck`
- [ ] Ran `./gradlew ktlintCheck`
- [ ] Ran `./gradlew detekt`
- [ ] Security scan status checked when the change affects dependencies or release surfaces
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [x] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [ ] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [ ] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [ ] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [ ] Updated `CHANGELOG.md` (if needed)
- [ ] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
