### PR TITLE
Feat/persistent disk backed buffering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# Repository-wide fallback
+* @janhaesen
+
+# Core library
+/src/ @janhaesen
+/api/ @janhaesen
+/config/ @janhaesen
+
+# Documentation and release surfaces
+/README.md @janhaesen
+/CONTEXT.md @janhaesen
+/CONTRIBUTING.md @janhaesen
+/CHANGELOG.md @janhaesen
+/docs/ @janhaesen
+
+# Modules and examples
+/query-spi/ @janhaesen
+/benchmarks/ @janhaesen
+/examples/ @janhaesen
+/otel/ @janhaesen
+
+# CI and automation
+/.github/ @janhaesen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 
 ## [Unreleased]
 
-No unreleased changes yet.
+### Added
+- **Persistent disk-backed buffering and replay** (issue #13):
+  - New `PersistentObservabilitySink` decorator that journals encoded events to disk before delegated delivery and replays unacknowledged events after restart.
+  - Deterministic in-order replay with bounded retention via `maxPendingEvents` and `maxJournalBytes`.
+  - Strict corruption handling: truncated journal tails are discarded on recovery, while other journal corruption fails fast.
+
+### Changed
+- Clarified reliability documentation to distinguish `AUDIT_DURABLE` in-memory hardening from crash-safe persistent buffering and to document safe decorator composition around the new persistence boundary.
 
 ## [1.2.0] - 2026-03-30
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,30 @@ Keep changes aligned with that ordering unless you are intentionally changing th
 - Treat stable SPI surfaces carefully; see [`docs/spi-contract.md`](./docs/spi-contract.md).
 - Validate reliability-sensitive changes against `AUDIT_DURABLE`.
 
+## Language
+
+**Persistent buffering**:
+Appending encoded events to a local durable journal before delegated delivery so unacknowledged events can survive process restarts.
+_Avoid_: Spool, disk queue, WAL
+
+**Replay**:
+Deterministic redelivery of journaled, unacknowledged events in their original sequence when a persistent buffer starts.
+_Avoid_: Recovery resend, best-effort resend
+
+**Acknowledged event**:
+A journaled event whose delegated delivery completed, allowing the persistent buffer to advance retention and cleanup.
+_Avoid_: Flushed event, processed event
+
+### Example dialogue
+
+> **Developer:** If the process crashes after buffering but before the sink confirms delivery, what do we call the next startup behavior?
+>
+> **Domain expert:** That's a **replay** of the unacknowledged events from the **persistent buffer**.
+>
+> **Developer:** And once the delegate sink accepts one of those events?
+>
+> **Domain expert:** It becomes an **acknowledged event**, so the buffer can clean it up.
+
 ## Where to look next
 
 - **Using the library:** [`README.md`](./README.md)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,18 +1,54 @@
-# Observability
+# Repository Context: observability
 
-This context defines the benchmark language used to describe repeatable performance scenarios and their documented comparison outputs.
+`observability` is a Kotlin framework for emitting typed application events, enriching and processing them through a pipeline, and delivering them to one or more sinks with optional reliability and encryption.
 
-## Language
+Use this file as the **thin shared entry point** for contributors and agents. It complements the user-facing [`README.md`](./README.md) and the deeper agent references in [`agent.md`](./agent.md) and [`docs/agent/agent.full.md`](./docs/agent/agent.full.md).
 
-**Benchmark Scenario**:
-A named workload configuration used to compare observability runtime behavior under a specific sink or decorator pattern.
-_Avoid_: One-off run, ad hoc test
+## Core mental model
 
-**Comparative Result**:
-A documented side-by-side benchmark outcome that helps readers compare scenarios, while explicitly remaining illustrative rather than a hard performance guarantee.
-_Avoid_: Guarantee, SLA
+Every emitted event flows through the same stages:
 
-## Example dialogue
+1. `Observability` receives an `ObservabilityEvent`
+2. `ContextProvider`s merge ambient context
+3. `ObservabilityCodec` encodes the event into an `EncodedEvent`
+4. `MetadataEnricher`s attach runtime metadata
+5. `ObservabilityProcessor`s transform bytes and metadata
+6. configured sinks fan out delivery
 
-Dev: "Is a benchmark scenario the same thing as a published result?"
-Domain expert: "No. The scenario is the workload definition; the comparative result is the documented example output readers use to interpret the suite."
+Keep changes aligned with that ordering unless you are intentionally changing the public pipeline contract.
+
+## Repository map
+
+| Path | Purpose |
+| --- | --- |
+| `src/main/kotlin/io/github/aeshen/observability/` | core public API, pipeline, sinks, processors, diagnostics |
+| `query-spi/` | optional backend-agnostic audit query SPI |
+| `benchmarks/` | comparative performance and backpressure harness |
+| `examples/third-party-sink-example/` | reference external sink/provider module with conformance tests |
+| `docs/` | architecture notes, extension contracts, release docs, schemas, ADRs |
+| `otel/` | local OpenTelemetry collector setup for manual sink verification |
+| `api/observability.api` | binary compatibility snapshot used by `apiCheck` |
+
+## High-signal invariants
+
+- Treat this as a structured event framework, not a thin logging wrapper.
+- Preserve `Closeable` lifecycle semantics for `Observability` and sinks.
+- Keep optional integrations optional at runtime boundaries.
+- Treat stable SPI surfaces carefully; see [`docs/spi-contract.md`](./docs/spi-contract.md).
+- Validate reliability-sensitive changes against `AUDIT_DURABLE`.
+
+## Where to look next
+
+- **Using the library:** [`README.md`](./README.md)
+- **Contributing and validation commands:** [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+- **Documentation map:** [`docs/README.md`](./docs/README.md)
+- **Extension contracts:** [`docs/extensions.md`](./docs/extensions.md), [`docs/spi-contract.md`](./docs/spi-contract.md)
+- **Machine-readable event contract:** [`docs/event-schema.md`](./docs/event-schema.md), [`docs/schema/README.md`](./docs/schema/README.md)
+- **Architecture decisions:** [`docs/adr/`](./docs/adr/)
+
+## Default validation commands
+
+```bash
+./gradlew test apiCheck ktlintCheck detekt --no-daemon
+./gradlew publish --dry-run --no-daemon
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,23 @@ Useful focused commands:
 ```bash
 ./gradlew :query-spi:test --no-daemon
 ./gradlew :examples:third-party-sink-example:test --no-daemon
+./gradlew ktlintMainSourceSetCheck --no-daemon
 ./gradlew apiDump --no-daemon
 ./gradlew publish --dry-run --no-daemon
 ```
 
 Use `apiDump` when you intentionally change the published binary API and need to refresh `api/observability.api` after reviewing the compatibility impact.
+
+## IntelliJ and ktlint
+
+Gradle is the source of truth for Kotlin formatting in this repository. The build pins **ktlint `1.2.1`** and reads formatting rules from the root [`.editorconfig`](./.editorconfig).
+
+To keep IntelliJ aligned with CI:
+
+1. Re-import the Gradle project after pulling formatting-related changes.
+2. Keep IntelliJ **EditorConfig support enabled** so the repo's Kotlin formatting rules are applied.
+3. If you use an IntelliJ ktlint plugin, configure it to use **ktlint `1.2.1`**. If the plugin cannot match the Gradle-pinned version, prefer disabling the plugin inspection and rely on `./gradlew ktlintCheck` / `./gradlew ktlintFormat` instead.
+4. When IntelliJ and Gradle disagree, trust the Gradle result and use `./gradlew ktlintMainSourceSetCheck --no-daemon` to confirm the exact file-level outcome.
 
 ## Contribution expectations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,21 @@ Thanks for contributing to `observability`.
 ## Before you open a PR
 
 1. Read the root [`README.md`](./README.md) for the user-facing project shape.
-2. Read [`docs/spi-contract.md`](./docs/spi-contract.md) if your change touches extension points or `query-spi`.
-3. Read [`docs/release.md`](./docs/release.md) if your change affects versioning, release automation, or changelog flow.
+2. Read [`CONTEXT.md`](./CONTEXT.md) and [`docs/README.md`](./docs/README.md) for the repository map and doc index.
+3. Read [`docs/spi-contract.md`](./docs/spi-contract.md) if your change touches extension points or `query-spi`.
+4. Read [`docs/release.md`](./docs/release.md) if your change affects versioning, release automation, or changelog flow.
+
+## Project structure at a glance
+
+| Path | Purpose |
+| --- | --- |
+| `src/main/kotlin/io/github/aeshen/observability/` | core public API, pipeline, sinks, codecs, processors, diagnostics |
+| `src/test/` | behavior-focused tests for the core library |
+| `src/testFixtures/` | shared conformance and support fixtures consumed by examples and extension modules |
+| `query-spi/` | optional audit query contracts for backend authors |
+| `benchmarks/` | comparative performance scenarios |
+| `examples/third-party-sink-example/` | reference external sink/provider module |
+| `api/observability.api` | binary compatibility baseline managed by the Kotlin binary compatibility validator |
 
 ## Local validation
 
@@ -21,8 +34,11 @@ Useful focused commands:
 ```bash
 ./gradlew :query-spi:test --no-daemon
 ./gradlew :examples:third-party-sink-example:test --no-daemon
+./gradlew apiDump --no-daemon
 ./gradlew publish --dry-run --no-daemon
 ```
+
+Use `apiDump` when you intentionally change the published binary API and need to refresh `api/observability.api` after reviewing the compatibility impact.
 
 ## Contribution expectations
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This library may be more than you need if:
 - [Reliability Decorators](#reliability-decorators)
   - [AsyncObservabilitySink](#asyncobservabilitysink)
   - [BatchingObservabilitySink](#batchingobservabilitysink)
+  - [PersistentObservabilitySink](#persistentobservabilitysink)
   - [RetryingObservabilitySink](#retryingobservabilitysink)
 - [Profiles](#profiles)
 - [Configure Encryption](#configure-encryption)
@@ -109,7 +110,7 @@ Sinks (fan-out)      (write to Console, File, OpenTelemetry, …)
 - **Multiple sinks with fan-out** — Console, SLF4J, File (JSONL), ZipFile, OpenTelemetry OTLP, Kafka
 - **Optional encryption** — AES-GCM with a fixed key, or per-event data key wrapped with RSA-OAEP-256
 - **Sensitive-field filtering** — ordered allow/mask/remove processors for `context.*`, `metadata.*`, `message`, and `payload`
-- **Reliability decorators** — `AsyncObservabilitySink`, `BatchingObservabilitySink`, `RetryingObservabilitySink`
+- **Reliability decorators** — `AsyncObservabilitySink`, `BatchingObservabilitySink`, `PersistentObservabilitySink`, `RetryingObservabilitySink`
 - **Profiles** — `STANDARD` (best-effort) or `AUDIT_DURABLE` (strict, retried, batched)
 - **Pluggable codec** — default JSONL, fully replaceable
 - **Sink SPI** — register custom sinks via `SinkConfig` + `SinkRegistry`
@@ -689,6 +690,44 @@ val batchedSink =
 
 Remaining buffered events are flushed synchronously on `close()`.
 
+### PersistentObservabilitySink
+
+Durably journals encoded events to a local directory before delegated delivery so unacknowledged events survive process restarts and replay in-order on the next startup:
+
+```kotlin
+import io.github.aeshen.observability.sink.decorator.PersistentObservabilitySink
+import io.github.aeshen.observability.sink.decorator.RetryingObservabilitySink
+
+val durableSink =
+    PersistentObservabilitySink(
+        delegate =
+            RetryingObservabilitySink(
+                delegate = mySink,
+                maxAttempts = 5,
+            ),
+        directory = Path.of("./.observability-buffer"),
+        maxPendingEvents = 10_000,
+        maxJournalBytes = 64L * 1024 * 1024,
+        retryDelayMillis = 1000,
+        closeTimeoutMillis = 5000,
+    )
+```
+
+Delivery semantics:
+
+- `handle()` returns after the event is durably appended to the journal.
+- Delivery is **at-least-once**. If the process crashes after journaling but before acknowledgement, the event is replayed after restart.
+- Replay is deterministic and ordered: the oldest unacknowledged event is retried first, and later events wait behind it.
+- Retention is bounded by `maxPendingEvents` and `maxJournalBytes`; exceeding either limit throws `IllegalStateException` and rejects the new event.
+- A truncated tail caused by a crash during append is discarded automatically on restart. Other journal corruption fails fast during startup.
+
+Composition guidance:
+
+- Wrap **synchronous** sinks or synchronous decorators inside `PersistentObservabilitySink`.
+- `RetryingObservabilitySink` composes well inside the persistence boundary.
+- Do **not** wrap `BatchingObservabilitySink` or `AsyncObservabilitySink` inside `PersistentObservabilitySink`; they acknowledge before the underlying sink has actually delivered.
+- `AUDIT_DURABLE` does not enable persistent buffering. Use `PersistentObservabilitySink` explicitly when restart survival is required.
+
 ### RetryingObservabilitySink
 
 Retries transient sink failures with configurable backoff:
@@ -742,6 +781,8 @@ val observability =
         ),
     )
 ```
+
+`AUDIT_DURABLE` improves in-memory reliability but is **not** crash-safe. Add `PersistentObservabilitySink` explicitly if events must survive restarts.
 
 ---
 
@@ -1118,6 +1159,7 @@ All decorator constructors use `@JvmOverloads`; optional parameters default to s
 ObservabilitySink retrying  = new RetryingObservabilitySink(delegate);
 ObservabilitySink batching  = new BatchingObservabilitySink(delegate);
 ObservabilitySink async     = new AsyncObservabilitySink(delegate);
+ObservabilitySink durable   = new PersistentObservabilitySink(delegate, bufferDir);
 ```
 
 ### Backoff strategies
@@ -1388,6 +1430,17 @@ To auto-format Kotlin sources:
 
 ```bash
 ./gradlew ktlintFormat
+```
+
+IntelliJ alignment notes:
+
+- Gradle is the source of truth here; the build pins **ktlint `1.2.1`** and reads rules from [`.editorconfig`](./.editorconfig).
+- Keep IntelliJ **EditorConfig support enabled** and re-import the Gradle project after formatting-related changes.
+- If you use an IntelliJ ktlint plugin, configure it to the same ktlint version. If you cannot, prefer disabling the plugin inspection and rely on Gradle `ktlintCheck` / `ktlintFormat` to avoid false discrepancies.
+- To verify a main-source mismatch exactly as CI sees it, run:
+
+```bash
+./gradlew ktlintMainSourceSetCheck --no-daemon
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This library may be more than you need if:
 - **Sink integrators**: jump to [Extend with Custom Sinks](#extend-with-custom-sinks), [`docs/extensions.md`](./docs/extensions.md), and [Conformance Testing](#conformance-testing)
 - **Query backend authors**: jump to [Query SPI](#query-spi) and [`query-spi/README.md`](./query-spi/README.md)
 - **Contributors and release maintainers**: see [`CONTRIBUTING.md`](./CONTRIBUTING.md), [`SECURITY.md`](./SECURITY.md), and [`docs/release.md`](./docs/release.md)
+- **Need the repo map first?** Start with [`CONTEXT.md`](./CONTEXT.md) and [`docs/README.md`](./docs/README.md)
 
 ## Table of Contents
 
@@ -1399,6 +1400,8 @@ To auto-format Kotlin sources:
 | `:query-spi`                            | Optional: backend-agnostic audit record query SPI                    |
 | `:benchmarks`                           | Comparative performance and backpressure harness                     |
 | `:examples:third-party-sink-example`    | Example custom sink module with SPI wiring and conformance tests     |
+
+For the contributor-facing repository map and deeper doc index, see [`CONTEXT.md`](./CONTEXT.md) and [`docs/README.md`](./docs/README.md).
 
 ---
 

--- a/agent.md
+++ b/agent.md
@@ -3,6 +3,9 @@
 Canonical deep reference: `docs/agent/agent.full.md`
 If this file and the full file diverge, treat `docs/agent/agent.full.md` as source of truth.
 
+Shared repository entry point: `CONTEXT.md`
+Use `CONTEXT.md` for the thin repo-wide map, this file for quick agent-oriented landmarks, and `docs/agent/agent.full.md` for deeper implementation context.
+
 ## Mission
 
 `observability` is a Kotlin framework for structured application observability:

--- a/api/observability.api
+++ b/api/observability.api
@@ -805,6 +805,19 @@ public final class io/github/aeshen/observability/sink/decorator/BatchingObserva
 	public fun handle (Lio/github/aeshen/observability/codec/EncodedEvent;)V
 }
 
+public final class io/github/aeshen/observability/sink/decorator/PersistentObservabilitySink : io/github/aeshen/observability/sink/ObservabilitySink {
+	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/nio/file/Path;)V
+	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/nio/file/Path;I)V
+	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/nio/file/Path;IJ)V
+	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/nio/file/Path;IJJ)V
+	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/nio/file/Path;IJJJ)V
+	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/nio/file/Path;IJJJLkotlin/jvm/functions/Function2;)V
+	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/nio/file/Path;IJJJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/nio/file/Path;IJJJLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public fun handle (Lio/github/aeshen/observability/codec/EncodedEvent;)V
+}
+
 public final class io/github/aeshen/observability/sink/decorator/RetryingObservabilitySink : io/github/aeshen/observability/sink/ObservabilitySink {
 	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;)V
 	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;I)V

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,6 +10,16 @@ It is designed for:
 
 It is **not** intended to be a universal performance claim for all JVMs, workloads, or deployment environments.
 
+## Benchmark language
+
+**Benchmark Scenario**:
+A named workload configuration used to compare observability runtime behavior under a specific sink or decorator pattern.
+_Avoid_: one-off run, ad hoc test
+
+**Comparative Result**:
+A documented side-by-side benchmark outcome that helps readers compare scenarios, while explicitly remaining illustrative rather than a hard performance guarantee.
+_Avoid_: guarantee, SLA
+
 ## What the suite covers
 
 The current scenario set includes:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     `maven-publish`
 }
 
+val ktlintVersion = "1.2.1"
 val openTelemetryVersion = "1.49.0"
 
 group = providers.gradleProperty("GROUP").get()
@@ -34,7 +35,7 @@ tasks.withType<Detekt>().configureEach {
 }
 
 configure<KtlintExtension> {
-    version.set("1.2.1")
+    version.set(ktlintVersion)
 }
 
 tasks.matching { it.name == "check" }.configureEach {
@@ -58,7 +59,7 @@ subprojects {
     }
 
     extensions.configure<KtlintExtension> {
-        version.set("1.2.1")
+        version.set(ktlintVersion)
     }
 
     tasks.matching { it.name == "check" }.configureEach {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Documentation Map
+
+Use this directory as the **map of deep references**, not as a second project overview.
+
+## Start here
+
+| Need | Read |
+| --- | --- |
+| Shared repository overview | [`../CONTEXT.md`](../CONTEXT.md) |
+| User-facing API and setup | [`../README.md`](../README.md) |
+| Contributor workflow and validation | [`../CONTRIBUTING.md`](../CONTRIBUTING.md) |
+| Quick agent-oriented repo context | [`../agent.md`](../agent.md) |
+| Full agent-oriented deep context | [`agent/agent.full.md`](./agent/agent.full.md) |
+
+## Architecture and contracts
+
+| Topic | File |
+| --- | --- |
+| Extension seams for sinks, enrichers, and processors | [`extensions.md`](./extensions.md) |
+| Compatibility policy for stable SPI surfaces | [`spi-contract.md`](./spi-contract.md) |
+| Encoded event envelope contract | [`event-schema.md`](./event-schema.md) |
+| Machine-readable schemas | [`schema/README.md`](./schema/README.md) |
+| Recorded architecture decisions | [`adr/0001-separate-query-spi-module.md`](./adr/0001-separate-query-spi-module.md) |
+
+## Operations and release
+
+| Topic | File |
+| --- | --- |
+| Release workflow and versioning | [`release.md`](./release.md) |
+| Local OpenTelemetry collector support | [`../otel/README.md`](../otel/README.md) |
+
+## Documentation rules of thumb
+
+- Keep top-level context thin and stable.
+- Prefer colocated READMEs when a directory's purpose is not obvious.
+- Prefer contracts and examples over prose when behavior can be made explicit.
+- Update docs in the same change when public behavior, contributor workflow, or extension contracts change.

--- a/docs/adr/0001-separate-query-spi-module.md
+++ b/docs/adr/0001-separate-query-spi-module.md
@@ -1,0 +1,24 @@
+# ADR 0001: Keep the audit query SPI in a separate Gradle module
+
+- Status: Accepted
+- Date: 2026-05-25
+
+## Context
+
+The repository exposes two related but different surfaces:
+
+1. the core `observability` library for event emission, processing, and sink delivery
+2. an optional audit query abstraction used by backend-specific query implementations
+
+The query APIs are valuable to some adopters, but many applications only emit events and never need audit-record retrieval. The repository already reflects this split through the `:query-spi` module and separate documentation.
+
+## Decision
+
+Keep the audit query abstractions in the dedicated `:query-spi` Gradle module instead of folding them into the root library artifact.
+
+## Consequences
+
+- Consumers that only emit events do not need to depend on the query SPI.
+- Backend authors get a lightweight, backend-agnostic contract they can implement independently of the core sink/runtime pipeline.
+- Compatibility for query contracts can be documented and reviewed as a distinct surface alongside the sink SPI.
+- Repository documentation should keep pointing query backend authors to `query-spi/README.md` rather than treating query support as part of the minimum core path.

--- a/docs/adr/0002-persistent-buffering-as-a-decorator.md
+++ b/docs/adr/0002-persistent-buffering-as-a-decorator.md
@@ -1,0 +1,3 @@
+# ADR 0002: Model persistent buffering as a sink decorator
+
+Persistent buffering is a reliability concern that should compose with existing sinks rather than replace them, so the library will expose it as a public sink decorator with its own durable journal and replay semantics. This keeps disk-backed durability aligned with the existing reliability vocabulary (`AsyncObservabilitySink`, `BatchingObservabilitySink`, `RetryingObservabilitySink`) while making the delivery contract explicit: once persisted, events are replayed in order until acknowledged by the wrapped delegate.

--- a/docs/agent/agent.full.md
+++ b/docs/agent/agent.full.md
@@ -86,6 +86,7 @@ OpenTelemetry config validates queue/batch/timing constraints and defaults to OT
 Sink decorators under `sink/decorator/`:
 - `AsyncObservabilitySink`
 - `BatchingObservabilitySink`
+- `PersistentObservabilitySink`
 - `RetryingObservabilitySink`
 - `BackoffStrategy`
 

--- a/docs/agent/agent.full.md
+++ b/docs/agent/agent.full.md
@@ -1,9 +1,12 @@
 # Agent Context: observability
 
-Last updated: 2026-03-22
+Last updated: 2026-05-25
 Repository: `observability`
 Primary language: Kotlin (JVM, Kotlin 2.3.20)
 Build tool: Gradle Kotlin DSL
+
+Shared repository entry point: [`CONTEXT.md`](../../CONTEXT.md)
+Use `CONTEXT.md` for the thin repo-wide map and this document for deeper agent-specific implementation context.
 
 ## Project Purpose
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -147,8 +147,11 @@ Processors are applied in the order provided. When encryption is enabled, custom
 
 - `AsyncObservabilitySink` offloads writes to a worker queue and supports deterministic close timeout/policy.
 - `BatchingObservabilitySink` buffers events and flushes by size/interval.
+- `PersistentObservabilitySink` journals events to disk before delegated delivery and replays unacknowledged events after restart.
 - `BatchCapableObservabilitySink` allows optimized batch delivery.
 - `RetryingObservabilitySink` retries transient failures using `BackoffStrategy`.
+
+`PersistentObservabilitySink` assumes its wrapped delegate is the acknowledgement boundary. It composes well with synchronous sinks and `RetryingObservabilitySink`, but not with `AsyncObservabilitySink` or `BatchingObservabilitySink` inside the persistence boundary because those decorators return before final delivery.
 
 ```kotlin
 val reliable =
@@ -200,4 +203,3 @@ Use `ObservabilitySinkConformanceSuite` from test fixtures in your sink module a
 - `observedEvents()`
 
 This verifies baseline behavior for event forwarding and close semantics.
-

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -1,0 +1,17 @@
+# Schema Directory
+
+This directory holds **machine-readable contracts** for emitted observability payloads.
+
+## Current contents
+
+| File | Meaning |
+| --- | --- |
+| `event-envelope-v1.schema.json` | canonical JSON Schema for the default `JsonLineCodec` envelope |
+
+## How to use these files
+
+- Treat the schema files as the canonical contract for tooling, validation, and downstream integrations.
+- Keep the matching prose explanation in [`../event-schema.md`](../event-schema.md) aligned with the schema.
+- Additive changes stay within the same schema version; breaking changes require a new schema versioned file.
+
+When changing `JsonLineCodec`, update the schema and its documentation in the same change.

--- a/docs/spi-contract.md
+++ b/docs/spi-contract.md
@@ -46,6 +46,8 @@ The `AUDIT_DURABLE` profile enforces strict reliability semantics:
 - Enables `failOnSinkError = true` to surface failures
 - All outcomes are reported via `ObservabilityDiagnostics`
 
+`AUDIT_DURABLE` is not crash-safe persistence. If events must survive process restarts, wrap the runtime sink with `PersistentObservabilitySink` explicitly.
+
 Use when strict audit compliance is required:
 
 ```kotlin
@@ -108,7 +110,7 @@ The optional `query-spi` module enables backend-agnostic audit record retrieval:
 - Operator diagnostics: implement `ObservabilityDiagnostics` and pass through `ObservabilityFactory.Config`.
 - Runtime sink wiring: pass `SinkConfig` entries via `ObservabilityFactory.Config.sinks` and resolve through `SinkRegistry`.
 - Legacy compatibility: `ObservabilityFactory.create(vararg sinks, ...)` still exists as a deprecated bridge and is not the recommended SPI wiring path.
-- Reliability wrappers: `RetryingObservabilitySink`, `AsyncObservabilitySink`, `BatchingObservabilitySink`.
+- Reliability wrappers: `RetryingObservabilitySink`, `AsyncObservabilitySink`, `BatchingObservabilitySink`, `PersistentObservabilitySink`.
 - Audit queries: implement `AuditSearchQueryService`; expose `AuditQueryService` only as a compatibility adapter when needed.
 
 ## Compatibility Process

--- a/otel/README.md
+++ b/otel/README.md
@@ -1,0 +1,20 @@
+# OpenTelemetry Local Setup
+
+This directory contains the local collector setup used by the repository examples and manual OpenTelemetry sink checks.
+
+## Contents
+
+| File | Purpose |
+| --- | --- |
+| `collector.yaml` | collector pipeline configuration |
+| `docker-compose.yml` | launches a local collector with OTLP gRPC (`4317`) and OTLP HTTP (`4318`) exposed |
+
+## Common commands
+
+```bash
+docker compose -f otel/docker-compose.yml up
+docker compose -f otel/docker-compose.yml logs -f otel-collector
+docker compose -f otel/docker-compose.yml down
+```
+
+For the end-to-end example and sink wiring details, see the [OpenTelemetry Setup section in the root README](../README.md#opentelemetry-setup).

--- a/src/main/kotlin/io/github/aeshen/observability/sink/decorator/PersistentObservabilitySink.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/sink/decorator/PersistentObservabilitySink.kt
@@ -1,0 +1,801 @@
+package io.github.aeshen.observability.sink.decorator
+
+import io.github.aeshen.observability.EventName
+import io.github.aeshen.observability.ObservabilityContext
+import io.github.aeshen.observability.ObservabilityEvent
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.key.TypedKey
+import io.github.aeshen.observability.sink.EventLevel
+import io.github.aeshen.observability.sink.ObservabilitySink
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.Closeable
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import java.util.zip.CRC32
+import kotlin.time.Instant
+
+private const val DEFAULT_MAX_PENDING_EVENTS = 10_000
+private const val DEFAULT_MAX_JOURNAL_BYTES = 64L * 1024 * 1024
+private const val DEFAULT_RETRY_DELAY_MILLIS = 1_000L
+private const val DEFAULT_CLOSE_TIMEOUT_MILLIS = 5_000L
+private const val JOURNAL_HEADER_BYTES = 22
+private const val JOURNAL_MAGIC = 0x4F425350
+private const val JOURNAL_VERSION: Short = 1
+private const val MIN_COMPACTION_BYTES = 64L * 1024L
+private const val COMPACTION_DIVISOR = 4L
+
+/**
+ * Decorator that durably journals encoded events before delegated delivery so they can be replayed
+ * after process restarts.
+ *
+ * The wrapped delegate is treated as the acknowledgement boundary. Use delegates whose `handle`
+ * call returns only after delivery has been attempted synchronously.
+ */
+class PersistentObservabilitySink
+    @JvmOverloads
+    constructor(
+        private val delegate: ObservabilitySink,
+        directory: Path,
+        private val maxPendingEvents: Int = DEFAULT_MAX_PENDING_EVENTS,
+        private val maxJournalBytes: Long = DEFAULT_MAX_JOURNAL_BYTES,
+        private val retryDelayMillis: Long = DEFAULT_RETRY_DELAY_MILLIS,
+        private val closeTimeoutMillis: Long = DEFAULT_CLOSE_TIMEOUT_MILLIS,
+        private val joinWorker: (Thread, Long) -> Unit = { thread, timeout -> thread.join(timeout) },
+        private val sleepBeforeRetry: (Long) -> Unit = { millis -> Thread.sleep(millis) },
+    ) : ObservabilitySink {
+        init {
+            require(maxPendingEvents > 0) { "maxPendingEvents must be greater than 0." }
+            require(maxJournalBytes > 0) { "maxJournalBytes must be greater than 0." }
+            require(retryDelayMillis >= 0) { "retryDelayMillis must be greater than or equal to 0." }
+            require(closeTimeoutMillis > 0) { "closeTimeoutMillis must be greater than 0." }
+        }
+
+        private val journal = PersistentJournal(directory, maxPendingEvents, maxJournalBytes)
+        private val accepting = AtomicBoolean(true)
+        private val workerFailure = AtomicReference<Exception?>(null)
+        private val worker =
+            Thread({ runLoop() }, "observability-persistent-sink").apply {
+                isDaemon = true
+                start()
+            }
+
+        override fun handle(event: EncodedEvent) {
+            val snapshot = event.snapshot()
+            if (!accepting.get()) {
+                check(false) { "PersistentObservabilitySink is closed." }
+            }
+
+            workerFailure.get()?.let { failure ->
+                throw IllegalStateException("Persistent sink worker has failed.", failure)
+            }
+
+            journal.append(snapshot)
+        }
+
+        override fun close() {
+            if (!accepting.compareAndSet(true, false)) {
+                return
+            }
+
+            journal.markClosing()
+            joinWorker(worker, closeTimeoutMillis)
+
+            var closeFailure: Exception? = null
+            if (worker.isAlive) {
+                worker.interrupt()
+            }
+
+            workerFailure.get()?.let { failure ->
+                closeFailure = IllegalStateException("Persistent sink worker failed before close.", failure)
+            }
+
+            try {
+                delegate.close()
+            } catch (e: IOException) {
+                closeFailure = mergeCloseFailure(closeFailure, e)
+            } catch (e: IllegalArgumentException) {
+                closeFailure = mergeCloseFailure(closeFailure, e)
+            } catch (e: IllegalStateException) {
+                closeFailure = mergeCloseFailure(closeFailure, e)
+            }
+
+            try {
+                journal.close()
+            } catch (e: IOException) {
+                closeFailure = mergeCloseFailure(closeFailure, e)
+            } catch (e: IllegalStateException) {
+                closeFailure = mergeCloseFailure(closeFailure, e)
+            }
+
+            closeFailure?.let { throw it }
+        }
+
+        private fun runLoop() {
+            while (true) {
+                val entry = journal.awaitHead() ?: return
+                if (tryDeliver(entry)) {
+                    journal.acknowledge(entry.sequence)
+                    continue
+                }
+
+                if (!sleepForRetry()) {
+                    return
+                }
+            }
+        }
+
+        @Suppress("TooGenericExceptionCaught")
+        private fun tryDeliver(entry: PendingRecord): Boolean =
+            try {
+                delegate.handle(entry.event.snapshot())
+                true
+            } catch (_: IllegalArgumentException) {
+                false
+            } catch (_: IllegalStateException) {
+                false
+            } catch (e: RuntimeException) {
+                workerFailure.compareAndSet(null, e)
+                accepting.set(false)
+                journal.markClosing()
+                false
+            }
+
+        private fun sleepForRetry(): Boolean =
+            try {
+                sleepBeforeRetry(retryDelayMillis)
+                workerFailure.get() == null
+            } catch (_: InterruptedException) {
+                accepting.get()
+            }
+
+        private fun mergeCloseFailure(
+            currentFailure: Exception?,
+            newFailure: Exception,
+        ): Exception = currentFailure?.apply { addSuppressed(newFailure) } ?: newFailure
+    }
+
+private class PersistentJournal(
+    directory: Path,
+    private val maxPendingEvents: Int,
+    private val maxJournalBytes: Long,
+) : Closeable {
+    private val journalPath = directory.resolve("persistent-buffer.journal")
+    private val statePath = directory.resolve("persistent-buffer.state")
+
+    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+    private val lock = java.lang.Object()
+    private val pending = ArrayDeque<PendingRecord>()
+    private var pendingBytes = 0L
+    private var acknowledgedBytesSinceCompaction = 0L
+    private var nextSequence: Long
+    private var closing = false
+    private var channel: FileChannel
+
+    init {
+        Files.createDirectories(directory)
+        val recovery = recover()
+        pending += recovery.pending
+        pendingBytes = recovery.pendingBytes
+        nextSequence = recovery.nextSequence
+        require(pending.size <= maxPendingEvents) {
+            "Recovered journal exceeds maxPendingEvents=$maxPendingEvents."
+        }
+        require(pendingBytes <= maxJournalBytes) {
+            "Recovered journal exceeds maxJournalBytes=$maxJournalBytes."
+        }
+        channel =
+            FileChannel.open(
+                journalPath,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE,
+            ).apply {
+                position(size())
+            }
+    }
+
+    fun append(event: EncodedEvent) {
+        val sequence =
+            synchronized(lock) {
+                val allocated = nextSequence
+                nextSequence += 1
+                allocated
+            }
+        val encodedRecord = PersistentJournalCodec.encode(sequence, event)
+        synchronized(lock) {
+            check(!closing) { "Persistent journal is closed." }
+            check(pending.size < maxPendingEvents) {
+                "Persistent journal is full (maxPendingEvents=$maxPendingEvents)."
+            }
+            check(pendingBytes + encodedRecord.size <= maxJournalBytes) {
+                "Persistent journal exceeded maxJournalBytes=$maxJournalBytes."
+            }
+
+            appendBytes(encodedRecord)
+            pending += PendingRecord(sequence = sequence, event = event, recordSize = encodedRecord.size.toLong())
+            pendingBytes += encodedRecord.size.toLong()
+            lock.notifyAll()
+        }
+    }
+
+    fun awaitHead(): PendingRecord? =
+        synchronized(lock) {
+            while (pending.isEmpty()) {
+                if (closing) {
+                    return null
+                }
+                try {
+                    lock.wait()
+                } catch (_: InterruptedException) {
+                    return null
+                }
+            }
+            pending.first()
+        }
+
+    fun acknowledge(sequence: Long) {
+        synchronized(lock) {
+            val head =
+                pending.removeFirstOrNull()
+                    ?: error("Cannot acknowledge sequence $sequence because the journal is empty.")
+            check(head.sequence == sequence) {
+                "Attempted to acknowledge sequence $sequence while head is ${head.sequence}."
+            }
+
+            pendingBytes -= head.recordSize
+            acknowledgedBytesSinceCompaction += head.recordSize
+            persistAcknowledgement(sequence)
+            compactIfNeeded()
+        }
+    }
+
+    fun markClosing() {
+        synchronized(lock) {
+            closing = true
+            lock.notifyAll()
+        }
+    }
+
+    override fun close() {
+        synchronized(lock) {
+            channel.close()
+        }
+    }
+
+    @Suppress("LoopWithTooManyJumpStatements")
+    private fun recover(): RecoveryResult {
+        if (!Files.exists(journalPath)) {
+            return RecoveryResult(emptyList(), 0L, readAcknowledgedSequence() + 1L)
+        }
+
+        val acknowledgedSequence = readAcknowledgedSequence()
+        val recovered = mutableListOf<PendingRecord>()
+        var recoveredBytes = 0L
+        var position = 0L
+        var lastSequence = acknowledgedSequence
+        FileChannel.open(
+            journalPath,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.READ,
+            StandardOpenOption.WRITE,
+        ).use { file ->
+            val size = file.size()
+            while (position < size) {
+                val record = PersistentJournalCodec.decode(file, position, size)
+                if (record == null) {
+                    file.truncate(position)
+                    break
+                }
+                position += record.totalBytes
+                lastSequence = record.sequence
+                if (record.sequence <= acknowledgedSequence) {
+                    continue
+                }
+                recovered +=
+                    PendingRecord(
+                        sequence = record.sequence,
+                        event = record.event,
+                        recordSize = record.totalBytes,
+                    )
+                recoveredBytes += record.totalBytes
+            }
+        }
+        return RecoveryResult(recovered, recoveredBytes, lastSequence + 1L)
+    }
+
+    private fun readAcknowledgedSequence(): Long {
+        if (!Files.exists(statePath)) {
+            return -1L
+        }
+
+        DataInputStream(Files.newInputStream(statePath)).use { input ->
+            return input.readLong()
+        }
+    }
+
+    private fun persistAcknowledgement(sequence: Long) {
+        val tmpState = statePath.resolveSibling("${statePath.fileName}.tmp")
+        DataOutputStream(
+            Files.newOutputStream(
+                tmpState,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE,
+            ),
+        ).use { output ->
+            output.writeLong(sequence)
+            output.flush()
+        }
+        moveAtomically(tmpState, statePath)
+    }
+
+    private fun appendBytes(bytes: ByteArray) {
+        channel.position(channel.size())
+        writeFully(channel, ByteBuffer.wrap(bytes))
+        channel.force(true)
+    }
+
+    private fun compactIfNeeded() {
+        if (pending.isEmpty()) {
+            channel.truncate(0)
+            channel.force(true)
+            channel.position(0)
+            acknowledgedBytesSinceCompaction = 0L
+            return
+        }
+
+        val threshold = maxOf(MIN_COMPACTION_BYTES, maxJournalBytes / COMPACTION_DIVISOR)
+        if (acknowledgedBytesSinceCompaction < threshold) {
+            return
+        }
+
+        val tmpJournal = journalPath.resolveSibling("${journalPath.fileName}.tmp")
+        FileChannel.open(
+            tmpJournal,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING,
+            StandardOpenOption.WRITE,
+        ).use { tempChannel ->
+            pending.forEach { record ->
+                val bytes = PersistentJournalCodec.encode(record.sequence, record.event)
+                writeFully(tempChannel, ByteBuffer.wrap(bytes))
+            }
+            tempChannel.force(true)
+        }
+
+        channel.close()
+        moveAtomically(tmpJournal, journalPath)
+        channel =
+            FileChannel.open(
+                journalPath,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE,
+            ).apply {
+                position(size())
+            }
+        acknowledgedBytesSinceCompaction = 0L
+    }
+
+    private fun moveAtomically(
+        source: Path,
+        target: Path,
+    ) {
+        try {
+            Files.move(
+                source,
+                target,
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+}
+
+private data class RecoveryResult(
+    val pending: List<PendingRecord>,
+    val pendingBytes: Long,
+    val nextSequence: Long,
+)
+
+private data class PendingRecord(
+    val sequence: Long,
+    val event: EncodedEvent,
+    val recordSize: Long,
+)
+
+@Suppress("TooManyFunctions")
+private object PersistentJournalCodec {
+    fun encode(
+        sequence: Long,
+        event: EncodedEvent,
+    ): ByteArray {
+        val payload = encodeBody(event)
+        val checksum = CRC32().apply { update(payload) }.value.toInt()
+        val output = ByteArrayOutputStream()
+        DataOutputStream(output).use { data ->
+            data.writeInt(JOURNAL_MAGIC)
+            data.writeShort(JOURNAL_VERSION.toInt())
+            data.writeLong(sequence)
+            data.writeInt(payload.size)
+            data.writeInt(checksum)
+            data.write(payload)
+        }
+        return output.toByteArray()
+    }
+
+    fun decode(
+        channel: FileChannel,
+        position: Long,
+        fileSize: Long,
+    ): DecodedRecord? {
+        if (fileSize - position < JOURNAL_HEADER_BYTES) {
+            return null
+        }
+
+        val header = ByteBuffer.allocate(JOURNAL_HEADER_BYTES)
+        readFully(channel, header, position)
+        header.flip()
+
+        val magic = header.int
+        check(magic == JOURNAL_MAGIC) {
+            "Persistent journal is corrupted at byte offset $position."
+        }
+
+        val version = header.short
+        check(version == JOURNAL_VERSION) {
+            "Unsupported persistent journal version $version."
+        }
+
+        val sequence = header.long
+        val payloadSize = header.int
+        val checksum = header.int
+        check(payloadSize >= 0) {
+            "Persistent journal declared a negative payload size at sequence $sequence."
+        }
+
+        val totalBytes = JOURNAL_HEADER_BYTES + payloadSize.toLong()
+        if (fileSize - position < totalBytes) {
+            return null
+        }
+
+        val payload = ByteBuffer.allocate(payloadSize)
+        readFully(channel, payload, position + JOURNAL_HEADER_BYTES)
+        val bytes = payload.array()
+        val actualChecksum = CRC32().apply { update(bytes) }.value.toInt()
+        check(actualChecksum == checksum) {
+            "Persistent journal checksum mismatch at sequence $sequence."
+        }
+
+        return DecodedRecord(
+            sequence = sequence,
+            event = decodeBody(bytes),
+            totalBytes = totalBytes,
+        )
+    }
+
+    private fun encodeBody(event: EncodedEvent): ByteArray =
+        ByteArrayOutputStream().also { output ->
+            DataOutputStream(output).use { data ->
+                val original = event.original
+                writeString(data, original.name.name)
+                writeNullableString(data, original.name.eventName)
+                writeString(data, original.level.name)
+                data.writeLong(original.timestamp.epochSeconds)
+                data.writeInt(original.timestamp.nanosecondsOfSecond)
+                writeNullableString(data, original.message)
+                writeNullableBytes(data, original.payload)
+                writeNullableThrowable(data, original.error)
+                writeContext(data, original.context)
+                writeMetadata(data, event.metadata)
+                writeBytes(data, event.encoded)
+            }
+        }.toByteArray()
+
+    private fun decodeBody(bytes: ByteArray): EncodedEvent =
+        DataInputStream(ByteArrayInputStream(bytes)).use { data ->
+            val eventName = PersistedEventName(name = readString(data), eventName = readNullableString(data))
+            val level = EventLevel.valueOf(readString(data))
+            val timestamp = Instant.fromEpochSeconds(data.readLong(), data.readInt().toLong())
+            val message = readNullableString(data)
+            val payload = readNullableBytes(data)
+            val error = readNullableThrowable(data)
+            val context = readContext(data)
+            val metadata = readMetadata(data)
+            val encoded = readBytes(data)
+            EncodedEvent(
+                original =
+                    ObservabilityEvent.EventBuilder(eventName)
+                        .level(level)
+                        .timestamp(timestamp)
+                        .context(context)
+                        .apply {
+                            message?.let(::message)
+                            payload?.let(::payload)
+                            error?.let(::error)
+                        }.build(),
+                encoded = encoded,
+                metadata = metadata,
+            )
+        }
+
+    private fun writeContext(
+        data: DataOutputStream,
+        context: ObservabilityContext,
+    ) {
+        val entries = context.asMap().entries.toList()
+        data.writeInt(entries.size)
+        entries.forEach { (key, value) ->
+            writeString(data, key.keyName)
+            writeNullableScalar(data, value)
+        }
+    }
+
+    private fun readContext(data: DataInputStream): ObservabilityContext {
+        val count = data.readInt()
+        val builder = ObservabilityContext.builder()
+        repeat(count) {
+            val keyName = readString(data)
+            val value = readNullableScalar(data)
+            if (value != null) {
+                builder.put(PersistedTypedKey<Any?>(keyName), value)
+            }
+        }
+        return builder.build()
+    }
+
+    private fun writeMetadata(
+        data: DataOutputStream,
+        metadata: Map<String, Any?>,
+    ) {
+        data.writeInt(metadata.size)
+        metadata.forEach { (key, value) ->
+            writeString(data, key)
+            writeNullableScalar(data, value)
+        }
+    }
+
+    private fun readMetadata(data: DataInputStream): MutableMap<String, Any?> {
+        val count = data.readInt()
+        val metadata = linkedMapOf<String, Any?>()
+        repeat(count) {
+            metadata[readString(data)] = readNullableScalar(data)
+        }
+        return metadata
+    }
+
+    private fun writeNullableThrowable(
+        data: DataOutputStream,
+        throwable: Throwable?,
+    ) {
+        data.writeBoolean(throwable != null)
+        if (throwable == null) {
+            return
+        }
+
+        writeString(data, throwable.javaClass.name)
+        writeNullableString(data, throwable.message)
+        writeString(data, throwable.stackTraceToString())
+    }
+
+    private fun readNullableThrowable(data: DataInputStream): Throwable? {
+        if (!data.readBoolean()) {
+            return null
+        }
+
+        return ReplayedObservabilityException(
+            originalClassName = readString(data),
+            originalMessage = readNullableString(data),
+            originalStacktrace = readString(data),
+        )
+    }
+
+    private fun writeNullableScalar(
+        data: DataOutputStream,
+        value: Any?,
+    ) {
+        when (value) {
+            null -> data.writeByte(ValueTag.NULL.ordinal)
+            is String -> {
+                data.writeByte(ValueTag.STRING.ordinal)
+                writeString(data, value)
+            }
+            is Boolean -> {
+                data.writeByte(ValueTag.BOOLEAN.ordinal)
+                data.writeBoolean(value)
+            }
+            is Byte -> {
+                data.writeByte(ValueTag.BYTE.ordinal)
+                data.writeByte(value.toInt())
+            }
+            is Short -> {
+                data.writeByte(ValueTag.SHORT.ordinal)
+                data.writeShort(value.toInt())
+            }
+            is Int -> {
+                data.writeByte(ValueTag.INT.ordinal)
+                data.writeInt(value)
+            }
+            is Long -> {
+                data.writeByte(ValueTag.LONG.ordinal)
+                data.writeLong(value)
+            }
+            is Float -> {
+                data.writeByte(ValueTag.FLOAT.ordinal)
+                data.writeFloat(value)
+            }
+            is Double -> {
+                data.writeByte(ValueTag.DOUBLE.ordinal)
+                data.writeDouble(value)
+            }
+            else -> throw IllegalArgumentException(
+                "PersistentObservabilitySink only supports scalar String/Boolean/number/null values. " +
+                    "Unsupported value type: ${value::class.qualifiedName}",
+            )
+        }
+    }
+
+    private fun readNullableScalar(data: DataInputStream): Any? =
+        when (ValueTag.entries[data.readUnsignedByte()]) {
+            ValueTag.NULL -> null
+            ValueTag.STRING -> readString(data)
+            ValueTag.BOOLEAN -> data.readBoolean()
+            ValueTag.BYTE -> data.readByte()
+            ValueTag.SHORT -> data.readShort()
+            ValueTag.INT -> data.readInt()
+            ValueTag.LONG -> data.readLong()
+            ValueTag.FLOAT -> data.readFloat()
+            ValueTag.DOUBLE -> data.readDouble()
+        }
+
+    private fun writeNullableString(
+        data: DataOutputStream,
+        value: String?,
+    ) {
+        data.writeBoolean(value != null)
+        value?.let { writeString(data, it) }
+    }
+
+    private fun readNullableString(data: DataInputStream): String? =
+        if (data.readBoolean()) {
+            readString(data)
+        } else {
+            null
+        }
+
+    private fun writeString(
+        data: DataOutputStream,
+        value: String,
+    ) {
+        writeBytes(data, value.toByteArray(Charsets.UTF_8))
+    }
+
+    private fun readString(data: DataInputStream): String = readBytes(data).toString(Charsets.UTF_8)
+
+    private fun writeNullableBytes(
+        data: DataOutputStream,
+        value: ByteArray?,
+    ) {
+        data.writeBoolean(value != null)
+        value?.let { writeBytes(data, it) }
+    }
+
+    private fun readNullableBytes(data: DataInputStream): ByteArray? =
+        if (data.readBoolean()) {
+            readBytes(data)
+        } else {
+            null
+        }
+
+    private fun writeBytes(
+        data: DataOutputStream,
+        value: ByteArray,
+    ) {
+        data.writeInt(value.size)
+        data.write(value)
+    }
+
+    private fun readBytes(data: DataInputStream): ByteArray {
+        val size = data.readInt()
+        check(size >= 0) { "Persistent journal encountered a negative byte-array length." }
+        return data.readNBytes(size).also { bytes ->
+            check(bytes.size == size) { "Persistent journal ended unexpectedly while reading record data." }
+        }
+    }
+}
+
+private data class DecodedRecord(
+    val sequence: Long,
+    val event: EncodedEvent,
+    val totalBytes: Long,
+)
+
+private enum class ValueTag {
+    NULL,
+    STRING,
+    BOOLEAN,
+    BYTE,
+    SHORT,
+    INT,
+    LONG,
+    FLOAT,
+    DOUBLE,
+}
+
+private data class PersistedEventName(
+    override val name: String,
+    override val eventName: String?,
+) : EventName
+
+private data class PersistedTypedKey<T>(
+    override val keyName: String,
+) : TypedKey<T>
+
+internal class ReplayedObservabilityException internal constructor(
+    val originalClassName: String,
+    val originalMessage: String?,
+    val originalStacktrace: String,
+) : RuntimeException(originalMessage) {
+    override fun fillInStackTrace(): Throwable = this
+
+    override fun toString(): String = originalMessage?.let { "$originalClassName: $it" } ?: originalClassName
+}
+
+private fun EncodedEvent.snapshot(): EncodedEvent =
+    EncodedEvent(
+        original = original.snapshot(),
+        encoded = encoded.copyOf(),
+        metadata = metadata.toMutableMap(),
+    )
+
+private fun ObservabilityEvent.snapshot(): ObservabilityEvent =
+    ObservabilityEvent.EventBuilder(PersistedEventName(name.name, name.eventName))
+        .level(level)
+        .timestamp(timestamp)
+        .context(context.snapshot())
+        .apply {
+            message?.let(::message)
+            payload?.let { payload(it.copyOf()) }
+            error?.let(::error)
+        }.build()
+
+private fun ObservabilityContext.snapshot(): ObservabilityContext {
+    val builder = ObservabilityContext.builder()
+    asMap().forEach { (key, value) -> builder.put(PersistedTypedKey<Any?>(key.keyName), value) }
+    return builder.build()
+}
+
+private fun readFully(
+    channel: FileChannel,
+    buffer: ByteBuffer,
+    startPosition: Long,
+) {
+    var position = startPosition
+    while (buffer.hasRemaining()) {
+        val read = channel.read(buffer, position)
+        check(read >= 0) { "Unexpected end of persistent journal." }
+        position += read.toLong()
+    }
+}
+
+private fun writeFully(
+    channel: FileChannel,
+    buffer: ByteBuffer,
+) {
+    while (buffer.hasRemaining()) {
+        channel.write(buffer)
+    }
+}

--- a/src/main/kotlin/io/github/aeshen/observability/sink/impl/OpenTelemetryObservabilitySink.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/sink/impl/OpenTelemetryObservabilitySink.kt
@@ -3,6 +3,7 @@ package io.github.aeshen.observability.sink.impl
 import io.github.aeshen.observability.codec.EncodedEvent
 import io.github.aeshen.observability.sink.EventLevel
 import io.github.aeshen.observability.sink.ObservabilitySink
+import io.github.aeshen.observability.sink.decorator.ReplayedObservabilityException
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -125,9 +126,19 @@ private fun EncodedEvent.toAttributes(): Attributes {
     }
 
     original.error?.let { throwable ->
-        putAttribute(builder, EXCEPTION_TYPE_KEY, throwable.javaClass.name)
-        throwable.message?.let { putAttribute(builder, EXCEPTION_MESSAGE_KEY, it) }
-        putAttribute(builder, EXCEPTION_STACKTRACE_KEY, throwable.stackTraceToString())
+        when (throwable) {
+            is ReplayedObservabilityException -> {
+                putAttribute(builder, EXCEPTION_TYPE_KEY, throwable.originalClassName)
+                throwable.originalMessage?.let { putAttribute(builder, EXCEPTION_MESSAGE_KEY, it) }
+                putAttribute(builder, EXCEPTION_STACKTRACE_KEY, throwable.originalStacktrace)
+            }
+
+            else -> {
+                putAttribute(builder, EXCEPTION_TYPE_KEY, throwable.javaClass.name)
+                throwable.message?.let { putAttribute(builder, EXCEPTION_MESSAGE_KEY, it) }
+                putAttribute(builder, EXCEPTION_STACKTRACE_KEY, throwable.stackTraceToString())
+            }
+        }
     }
 
     return builder.build()

--- a/src/test/kotlin/io/github/aeshen/observability/sink/decorator/PersistentObservabilitySinkTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/sink/decorator/PersistentObservabilitySinkTest.kt
@@ -1,0 +1,249 @@
+package io.github.aeshen.observability.sink.decorator
+
+import io.github.aeshen.observability.EventName
+import io.github.aeshen.observability.ObservabilityContext
+import io.github.aeshen.observability.ObservabilityEvent
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.codec.impl.JsonLineCodec
+import io.github.aeshen.observability.key.BooleanKey
+import io.github.aeshen.observability.key.LongKey
+import io.github.aeshen.observability.key.StringKey
+import io.github.aeshen.observability.sink.EventLevel
+import io.github.aeshen.observability.sink.ObservabilitySink
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class PersistentObservabilitySinkTest {
+    @Test
+    fun `replays persisted events after restart`() {
+        val directory = Files.createTempDirectory("obs-persistent-replay")
+        val first =
+            PersistentObservabilitySink(
+                delegate =
+                    object : ObservabilitySink {
+                        override fun handle(event: EncodedEvent) = error("delegate-down")
+                    },
+                directory = directory,
+                retryDelayMillis = 10,
+                closeTimeoutMillis = 25,
+            )
+
+        first.handle(sampleEncoded(message = "restart-me"))
+        Thread.sleep(40)
+        first.close()
+
+        val replayed = mutableListOf<EncodedEvent>()
+        val delivered = CountDownLatch(1)
+        PersistentObservabilitySink(
+            delegate = PersistentCapturingSink(replayed, delivered),
+            directory = directory,
+            retryDelayMillis = 10,
+            closeTimeoutMillis = 200,
+        ).use { sink ->
+            assertTrue(delivered.await(1, TimeUnit.SECONDS))
+            assertEquals("restart-me", replayed.single().original.message)
+            sink.close()
+        }
+    }
+
+    @Test
+    fun `does not replay acknowledged events on later restart`() {
+        val directory = Files.createTempDirectory("obs-persistent-ack")
+        val delivered = CountDownLatch(1)
+        PersistentObservabilitySink(
+            delegate = PersistentCapturingSink(mutableListOf(), delivered),
+            directory = directory,
+            retryDelayMillis = 10,
+            closeTimeoutMillis = 200,
+        ).use { sink ->
+            sink.handle(sampleEncoded(message = "deliver-once"))
+            assertTrue(delivered.await(1, TimeUnit.SECONDS))
+        }
+
+        val replayed = CountDownLatch(1)
+        PersistentObservabilitySink(
+            delegate =
+                object : ObservabilitySink {
+                    override fun handle(event: EncodedEvent) {
+                        replayed.countDown()
+                    }
+                },
+            directory = directory,
+            retryDelayMillis = 10,
+            closeTimeoutMillis = 50,
+        ).use {
+            assertFalse(replayed.await(150, TimeUnit.MILLISECONDS))
+        }
+    }
+
+    @Test
+    fun `replay preserves encoded bytes scalar context metadata and error details`() {
+        val directory = Files.createTempDirectory("obs-persistent-shape")
+        val initial =
+            PersistentObservabilitySink(
+                delegate =
+                    object : ObservabilitySink {
+                        override fun handle(event: EncodedEvent) {
+                            error("still-down")
+                        }
+                    },
+                directory = directory,
+                retryDelayMillis = 10,
+                closeTimeoutMillis = 25,
+            )
+        val source = sampleEncoded()
+
+        initial.handle(source)
+        Thread.sleep(40)
+        initial.close()
+
+        val replayed = Collections.synchronizedList(mutableListOf<EncodedEvent>())
+        val delivered = CountDownLatch(1)
+        PersistentObservabilitySink(
+            delegate = PersistentCapturingSink(replayed, delivered),
+            directory = directory,
+            retryDelayMillis = 10,
+            closeTimeoutMillis = 200,
+        ).use {
+            assertTrue(delivered.await(1, TimeUnit.SECONDS))
+        }
+
+        val restored = replayed.single()
+        assertTrue(restored.encoded.contentEquals(source.encoded))
+        assertEquals("TEST", restored.original.name.name)
+        assertEquals("durable.test", restored.original.name.eventName)
+        assertEquals("durable event", restored.original.message)
+        assertEquals(201, restored.original.context.get(LongKey.STATUS_CODE))
+        assertEquals("req-123", restored.original.context.get(StringKey.REQUEST_ID))
+        assertEquals(true, restored.original.context.get(BooleanKey.SUCCESS))
+        assertEquals(42L, restored.metadata["attempt"])
+        assertEquals("ingest", restored.metadata["source"])
+        val replayedError = assertIs<ReplayedObservabilityException>(restored.original.error)
+        assertEquals(IllegalArgumentException::class.qualifiedName, replayedError.originalClassName)
+        assertEquals("boom", replayedError.originalMessage)
+    }
+
+    @Test
+    fun `rejects unsupported scalar values`() {
+        val directory = Files.createTempDirectory("obs-persistent-invalid")
+        PersistentObservabilitySink(
+            delegate = NoopSink,
+            directory = directory,
+        ).use { sink ->
+            assertFailsWith<IllegalArgumentException> {
+                sink.handle(sampleEncoded(metadata = mutableMapOf("bad" to listOf("x"))))
+            }
+        }
+    }
+
+    @Test
+    fun `fails when pending retention bounds are exceeded`() {
+        val directory = Files.createTempDirectory("obs-persistent-bounds")
+        PersistentObservabilitySink(
+            delegate =
+                object : ObservabilitySink {
+                    override fun handle(event: EncodedEvent) = error("delegate-down")
+                },
+            directory = directory,
+            maxPendingEvents = 1,
+            retryDelayMillis = 10,
+            closeTimeoutMillis = 25,
+        ).use { sink ->
+            sink.handle(sampleEncoded(message = "first"))
+            assertFailsWith<IllegalStateException> {
+                sink.handle(sampleEncoded(message = "second"))
+            }
+        }
+    }
+
+    @Test
+    fun `truncates incomplete tail and replays intact records`() {
+        val directory = Files.createTempDirectory("obs-persistent-tail")
+        val initial =
+            PersistentObservabilitySink(
+                delegate =
+                    object : ObservabilitySink {
+                        override fun handle(event: EncodedEvent) = error("delegate-down")
+                    },
+                directory = directory,
+                retryDelayMillis = 10,
+                closeTimeoutMillis = 25,
+            )
+        initial.handle(sampleEncoded(message = "keep-me"))
+        Thread.sleep(40)
+        initial.close()
+
+        Files.write(
+            directory.resolve("persistent-buffer.journal"),
+            byteArrayOf(0x01, 0x02, 0x03),
+            StandardOpenOption.APPEND,
+        )
+
+        val replayed = mutableListOf<EncodedEvent>()
+        val delivered = CountDownLatch(1)
+        PersistentObservabilitySink(
+            delegate = PersistentCapturingSink(replayed, delivered),
+            directory = directory,
+            retryDelayMillis = 10,
+            closeTimeoutMillis = 200,
+        ).use {
+            assertTrue(delivered.await(1, TimeUnit.SECONDS))
+            assertEquals("keep-me", replayed.single().original.message)
+        }
+    }
+}
+
+private object NoopSink : ObservabilitySink {
+    override fun handle(event: EncodedEvent) = Unit
+}
+
+private class PersistentCapturingSink(
+    private val seen: MutableList<EncodedEvent>,
+    private val latch: CountDownLatch,
+) : ObservabilitySink {
+    override fun handle(event: EncodedEvent) {
+        seen += event
+        latch.countDown()
+    }
+}
+
+private fun sampleEncoded(
+    message: String = "durable event",
+    metadata: MutableMap<String, Any?> = mutableMapOf("attempt" to 42L, "source" to "ingest"),
+): EncodedEvent {
+    val context =
+        ObservabilityContext
+            .builder()
+            .put(StringKey.REQUEST_ID, "req-123")
+            .put(LongKey.STATUS_CODE, 201L)
+            .put(BooleanKey.SUCCESS, true)
+            .build()
+
+    val event =
+        ObservabilityEvent.EventBuilder(PersistentEvent.TEST)
+            .level(EventLevel.WARN)
+            .message(message)
+            .payload("payload".toByteArray(Charsets.UTF_8))
+            .context(context)
+            .error(IllegalArgumentException("boom"))
+            .build()
+
+    return JsonLineCodec().encode(event).apply {
+        this.metadata.putAll(metadata)
+    }
+}
+
+private enum class PersistentEvent(
+    override val eventName: String? = null,
+) : EventName {
+    TEST("durable.test"),
+}


### PR DESCRIPTION
## What changed

 Introduce PersistentObservabilitySink to journal encoded events to disk before
 delegated delivery, replay unacknowledged events after restart, enforce bounded
 retention, and make failure behavior explicit. Replay preserves encoded payloads,
 event identity, scalar context/metadata values, and restored exception details,
 with OpenTelemetry handling updated to retain original exception attributes.
 
 Cover the new behavior with tests for restart replay, acknowledgement cleanup,
 retention bounds, unsupported persisted values, and truncated-tail recovery.
 Document the durability model, composition constraints, and delivery semantics in
 the README, contributor docs, CONTEXT.md, and a new ADR, and clarify IntelliJ vs
 Gradle ktlint alignment by centralizing the pinned ktlint version in Gradle.

Closes #13 

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [x] Built-in sinks / decorators / providers
- [ ] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [x] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`)
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [x] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [x] Added/updated tests
- [x] Ran `./gradlew test`
- [ ] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew ktlintCheck`
- [x] Ran `./gradlew detekt`
- [ ] Security scan status checked when the change affects dependencies or release surfaces
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [x] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [x] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [x] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [x] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [x] Updated `CHANGELOG.md` (if needed)
- [x] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [x] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
