### PR TITLE
feat: define explicit delivery semantics profiles for sink delivery guarantees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on Keep a Changelog and the project follows Semantic Version
   - Strict corruption handling: truncated journal tails are discarded on recovery, while other journal corruption fails fast.
 
 ### Changed
-- Clarified reliability documentation to distinguish `AUDIT_DURABLE` in-memory hardening from crash-safe persistent buffering and to document safe decorator composition around the new persistence boundary.
+- Clarified delivery semantics and reliability documentation (issues #13, #14) to distinguish best-effort, strict, and durable delivery, to document `AUDIT_DURABLE` as an in-memory hardening profile rather than crash-safe durability, and to keep safe decorator composition explicit around the persistence boundary.
 
 ## [1.2.0] - 2026-03-30
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,6 +39,22 @@ Keep changes aligned with that ordering unless you are intentionally changing th
 
 ## Language
 
+**Delivery profile**:
+A named bundle of delivery defaults applied by `ObservabilityFactory`, such as `STANDARD` or `AUDIT_DURABLE`.
+_Avoid_: Reliability mode, guarantee level
+
+**Best-effort delivery**:
+Delivery where sink failures are observed through diagnostics but are not surfaced back to the caller by default.
+_Avoid_: Fire-and-forget, reliable by default
+
+**Strict delivery**:
+Delivery where sink failures are surfaced back to the caller instead of being swallowed by the pipeline.
+_Avoid_: Durable, guaranteed delivery
+
+**Durable delivery**:
+Delivery that survives process restarts because each event is appended to a persistent buffer before delegated handling continues.
+_Avoid_: Strict delivery, in-memory durability
+
 **Persistent buffering**:
 Appending encoded events to a local durable journal before delegated delivery so unacknowledged events can survive process restarts.
 _Avoid_: Spool, disk queue, WAL
@@ -51,8 +67,16 @@ _Avoid_: Recovery resend, best-effort resend
 A journaled event whose delegated delivery completed, allowing the persistent buffer to advance retention and cleanup.
 _Avoid_: Flushed event, processed event
 
+## Flagged ambiguities
+
+- `AUDIT_DURABLE` is a public profile name, but it is not **durable delivery** in the glossary sense because it does not enable persistent buffering. Treat it as an audit-oriented profile that makes delivery stricter with retry and batching while keeping the canonical meaning of **durable delivery** reserved for restart-surviving persistence.
+
 ### Example dialogue
 
+> **Developer:** If I set `AUDIT_DURABLE`, do I now have durable delivery?
+>
+> **Domain expert:** No. That profile makes delivery stricter and more resilient in memory, but **durable delivery** still requires a **persistent buffer**.
+>
 > **Developer:** If the process crashes after buffering but before the sink confirms delivery, what do we call the next startup behavior?
 >
 > **Domain expert:** That's a **replay** of the unacknowledged events from the **persistent buffer**.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Sinks (fan-out)      (write to Console, File, OpenTelemetry, …)
 - **Optional encryption** — AES-GCM with a fixed key, or per-event data key wrapped with RSA-OAEP-256
 - **Sensitive-field filtering** — ordered allow/mask/remove processors for `context.*`, `metadata.*`, `message`, and `payload`
 - **Reliability decorators** — `AsyncObservabilitySink`, `BatchingObservabilitySink`, `PersistentObservabilitySink`, `RetryingObservabilitySink`
-- **Profiles** — `STANDARD` (best-effort) or `AUDIT_DURABLE` (strict, retried, batched)
+- **Profiles** — `STANDARD` (best-effort) or `AUDIT_DURABLE` (strict, retried, batched; not crash-safe by itself)
 - **Pluggable codec** — default JSONL, fully replaceable
 - **Sink SPI** — register custom sinks via `SinkConfig` + `SinkRegistry`
 - **Global context injection** — `ContextProvider` merges ambient context into every event
@@ -761,6 +761,20 @@ val fixedRetrySink =
 
 ---
 
+## Delivery semantics
+
+Use these terms consistently when describing sink behavior:
+
+| Term | Meaning | Minimum configuration |
+| --- | --- | --- |
+| **Best-effort delivery** | Sink failures may be reported to diagnostics, but the pipeline does not surface them to the caller by default. | `STANDARD` profile, or any configuration with `failOnSinkError = false` |
+| **Strict delivery** | Sink failures are surfaced to the caller instead of being swallowed. | `failOnSinkError = true` |
+| **Durable delivery** | `handle()` returns only after the event has been appended to a persistent journal so it can replay after restart. | `PersistentObservabilitySink` |
+
+`RetryingObservabilitySink` and `BatchingObservabilitySink` improve delivery behavior, but neither one makes delivery durable on its own.
+
+---
+
 ## Profiles
 
 ### STANDARD (default)
@@ -769,7 +783,7 @@ Best-effort delivery. `IllegalArgumentException` and `IllegalStateException` fro
 
 ### AUDIT_DURABLE
 
-Automatically wraps all sinks with retry (5 attempts, exponential backoff), batching (100-event batches, 250 ms flush), and enforces `failOnSinkError = true`. Use for audit compliance scenarios:
+Automatically wraps all sinks with retry (5 attempts, exponential backoff), batching (100-event batches, 250 ms flush), and enforces `failOnSinkError = true`. Use for audit compliance scenarios when you want a stricter in-memory delivery profile:
 
 ```kotlin
 val observability =
@@ -782,7 +796,7 @@ val observability =
     )
 ```
 
-`AUDIT_DURABLE` improves in-memory reliability but is **not** crash-safe. Add `PersistentObservabilitySink` explicitly if events must survive restarts.
+`AUDIT_DURABLE` is a compatibility profile name, not the canonical definition of **durable delivery**. It improves in-memory reliability but is **not** crash-safe. Add `PersistentObservabilitySink` explicitly if events must survive restarts.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Use this directory as the **map of deep references**, not as a second project ov
 | Compatibility policy for stable SPI surfaces | [`spi-contract.md`](./spi-contract.md) |
 | Encoded event envelope contract | [`event-schema.md`](./event-schema.md) |
 | Machine-readable schemas | [`schema/README.md`](./schema/README.md) |
-| Recorded architecture decisions | [`adr/0001-separate-query-spi-module.md`](./adr/0001-separate-query-spi-module.md) |
+| Recorded architecture decisions | [`adr/`](./adr/) |
 
 ## Operations and release
 

--- a/docs/adr/0003-reserve-durable-for-restart-safe-delivery-semantics.md
+++ b/docs/adr/0003-reserve-durable-for-restart-safe-delivery-semantics.md
@@ -1,0 +1,3 @@
+# ADR 0003: Reserve "durable" for restart-safe delivery semantics
+
+The library distinguishes **best-effort**, **strict**, and **durable** delivery as separate concepts. **Durable delivery** refers only to journal-backed delivery that survives process restarts and replays unacknowledged events, which today is provided by `PersistentObservabilitySink`. The existing `AUDIT_DURABLE` profile name remains for compatibility, but documentation treats it as an audit-oriented strict/retry/batch profile rather than the canonical definition of durable delivery.


### PR DESCRIPTION
## What changed

- Updated CONTEXT.md to define delivery profile, best-effort delivery, strict delivery, and durable delivery, and to flag the AUDIT_DURABLE naming ambiguity explicitly.
- Updated README.md with a new Delivery semantics section and clarified that AUDIT_DURABLE is a compatibility profile name for strict/retried/batched in-memory delivery, not   crash-safe durability.
- Added docs/adr/0003-reserve-durable-for-restart-safe-delivery-semantics.md to record the compatibility trade-off.
- Updated docs/README.md to point at the ADR directory and CHANGELOG.md to reference the issue-#14 semantics clarification.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [ ] Built-in sinks / decorators / providers
- [ ] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [ ] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`)
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [x] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [ ] Added/updated tests
- [x] Ran `./gradlew test`
- [ ] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew ktlintCheck`
- [x] Ran `./gradlew detekt`
- [ ] Security scan status checked when the change affects dependencies or release surfaces
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [x] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [x] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [x] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [x] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [x] Updated `CHANGELOG.md` (if needed)
- [ ] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
