### PR TITLE
refactor: remove deprecated create from ObservabilityFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 ### Changed
 - Clarified delivery semantics and reliability documentation (issues #13, #14) to distinguish best-effort, strict, and durable delivery, to document `AUDIT_DURABLE` as an in-memory hardening profile rather than crash-safe durability, and to keep safe decorator composition explicit around the persistence boundary.
 
+### Breaking changes
+- **Removed deprecated direct-sink factory overload** (issue #30):
+  - Deleted `ObservabilityFactory.create(vararg sinks, ...)`.
+  - Removed the internal `LegacyDirectSinkConfig` compatibility shim.
+  - `ObservabilityFactory` sink wiring now always goes through `Config.sinks` and `SinkRegistry`.
+
+### Migration notes
+- Replace `ObservabilityFactory.create(ConsoleObservabilitySink(), ...)` with `ObservabilityFactory.create(ObservabilityFactory.Config(sinks = listOf(Console), ...))`.
+- If you need to pass a runtime sink instance, wrap it in a local `SinkConfig` and register a matching provider in a `SinkRegistry`, then pass both through `ObservabilityFactory.Config`.
+
 ### Breaking changes (`query-spi`)
 - **Removed deprecated legacy query SPI** (issue #28):
   - Deleted `AuditQueryService`, `AuditQuery`, `AuditPage`, and the `asLegacyService()` bridge extension.

--- a/api/observability.api
+++ b/api/observability.api
@@ -115,8 +115,6 @@ public final class io/github/aeshen/observability/ObservabilityEvents {
 public final class io/github/aeshen/observability/ObservabilityFactory {
 	public static final field INSTANCE Lio/github/aeshen/observability/ObservabilityFactory;
 	public static final fun create (Lio/github/aeshen/observability/ObservabilityFactory$Config;)Lio/github/aeshen/observability/Observability;
-	public final fun create ([Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;)Lio/github/aeshen/observability/Observability;
-	public static synthetic fun create$default (Lio/github/aeshen/observability/ObservabilityFactory;[Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;ILjava/lang/Object;)Lio/github/aeshen/observability/Observability;
 }
 
 public final class io/github/aeshen/observability/ObservabilityFactory$Config {

--- a/docs/spi-contract.md
+++ b/docs/spi-contract.md
@@ -106,7 +106,6 @@ The optional `query-spi` module enables backend-agnostic audit record retrieval:
 - Config-driven sink creation: custom `SinkConfig` + `SinkRegistry.builder().register<...> { ... }.build()`.
 - Operator diagnostics: implement `ObservabilityDiagnostics` and pass through `ObservabilityFactory.Config`.
 - Runtime sink wiring: pass `SinkConfig` entries via `ObservabilityFactory.Config.sinks` and resolve through `SinkRegistry`.
-- Legacy compatibility: `ObservabilityFactory.create(vararg sinks, ...)` still exists as a deprecated bridge and is not the recommended SPI wiring path.
 - Reliability wrappers: `RetryingObservabilitySink`, `AsyncObservabilitySink`, `BatchingObservabilitySink`, `PersistentObservabilitySink`.
 - Audit queries: implement `AuditSearchQueryService` with `AuditSearchQuery` and `AuditPagination`.
 

--- a/src/main/kotlin/io/github/aeshen/observability/ObservabilityFactory.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/ObservabilityFactory.kt
@@ -24,9 +24,6 @@ object ObservabilityFactory {
     private const val AUDIT_MAX_ATTEMPTS = 5
     private const val AUDIT_MAX_BATCH_SIZE = 100
     private const val AUDIT_FLUSH_INTERVAL_MILLIS = 250L
-    private const val LEGACY_CREATE_DEPRECATION_MESSAGE =
-        "Use create(Config) with SinkRegistry-based sink wiring. " +
-            "This overload is kept for backward compatibility."
 
     enum class Profile {
         STANDARD,
@@ -140,45 +137,6 @@ object ObservabilityFactory {
         )
     }
 
-    /**
-     * Legacy runtime-sink convenience API.
-     *
-     * Prefer [create] with [Config] and explicit [SinkRegistry] wiring.
-     */
-    @Deprecated(
-        message = LEGACY_CREATE_DEPRECATION_MESSAGE,
-    )
-    fun create(
-        vararg sinks: ObservabilitySink,
-        encryption: EncryptionConfig? = null,
-        failOnSinkError: Boolean = false,
-        codec: ObservabilityCodec = JsonLineCodec(),
-        contextProviders: List<ContextProvider> = emptyList(),
-        metadataEnrichers: List<MetadataEnricher> = emptyList(),
-        diagnostics: ObservabilityDiagnostics = ObservabilityDiagnostics.NOOP,
-        profile: Profile = Profile.STANDARD,
-    ): Observability {
-        val registry =
-            SinkRegistry
-                .builder()
-                .register<LegacyDirectSinkConfig> { cfg -> cfg.sink }
-                .build()
-
-        return create(
-            Config(
-                sinks = sinks.map { sink -> LegacyDirectSinkConfig(sink) },
-                encryption = encryption,
-                failOnSinkError = failOnSinkError,
-                sinkRegistry = registry,
-                codec = codec,
-                contextProviders = contextProviders,
-                metadataEnrichers = metadataEnrichers,
-                diagnostics = diagnostics,
-                profile = profile,
-            ),
-        )
-    }
-
     private fun buildSinks(config: Config): List<ObservabilitySink> = config.sinkRegistry.resolveAll(config.sinks)
 
     private fun buildProcessors(
@@ -216,10 +174,6 @@ object ObservabilityFactory {
         explicit: Boolean,
         profile: Profile,
     ): Boolean = if (profile == Profile.AUDIT_DURABLE) true else explicit
-
-    private data class LegacyDirectSinkConfig(
-        val sink: ObservabilitySink,
-    ) : SinkConfig
 
     private fun applyProfile(
         sinks: List<ObservabilitySink>,


### PR DESCRIPTION
## What changed

Removed the deprecated ObservabilityFactory.create(vararg sinks, ...) overload and deleted the internal LegacyDirectSinkConfig shim. Updated the API snapshot, removed the stale
   deprecated-bridge note from docs/spi-contract.md, and added 2.0 migration guidance to CHANGELOG.md.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [x] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [ ] Built-in sinks / decorators / providers
- [ ] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [ ] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`)
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [x] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [ ] Added/updated tests
- [x] Ran `./gradlew test`
- [ ] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew ktlintCheck`
- [x] Ran `./gradlew detekt`
- [ ] Security scan status checked when the change affects dependencies or release surfaces
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [x] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [ ] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [ ] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [ ] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [x] Updated `CHANGELOG.md` (if needed)
- [x] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
