### PR TITLE
refactor: make webhook signing optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,16 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 
 ### Changed
 - Clarified delivery semantics and reliability documentation (issues #13, #14) to distinguish best-effort, strict, and durable delivery, to document `AUDIT_DURABLE` as an in-memory hardening profile rather than crash-safe durability, and to keep safe decorator composition explicit around the persistence boundary.
+- `Webhook.secret` now accepts `null` to disable HMAC signing, and unsigned webhook deliveries omit the signature header entirely (issue #40).
 
 ### Breaking changes
 - **Removed deprecated direct-sink factory overload** (issue #30):
   - Deleted `ObservabilityFactory.create(vararg sinks, ...)`.
   - Removed the internal `LegacyDirectSinkConfig` compatibility shim.
   - `ObservabilityFactory` sink wiring now always goes through `Config.sinks` and `SinkRegistry`.
+- **`Webhook` secret opt-out is now nullable** (issue #40):
+  - `Webhook.secret` changed from `String` to `String?`, with `null` meaning unsigned delivery.
+  - Whitespace-only secrets remain invalid when a signing secret is provided.
 
 ### Migration notes
 - Replace `ObservabilityFactory.create(ConsoleObservabilitySink(), ...)` with `ObservabilityFactory.create(ObservabilityFactory.Config(sinks = listOf(Console), ...))`.

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ val config =
             ),
             Webhook(
                 endpoint = "https://hooks.example.com/observability",
-                secret = "my-signing-secret",
+                secret = "my-signing-secret", // optional: set to null for unsigned delivery
                 signatureHeader = "X-Hub-Signature-256",
                 headers = mapOf("Content-Type" to "application/json"),
             ),
@@ -544,7 +544,7 @@ val config =
 | `Http`           | Sends encoded payload bytes to an arbitrary HTTP/HTTPS endpoint (`POST`, `PUT`, `PATCH`) | None                                              |
 | `OpenTelemetry`  | Exports via OTLP HTTP to any OTel-compatible backend      | `opentelemetry-api`, `-sdk`, `-exporter-otlp`     |
 | `Kafka`          | Produces encoded events to a Kafka topic; supports SASL/SSL via `additionalProperties` | `org.apache.kafka:kafka-clients`                  |
-| `Webhook`        | HTTP POST with HMAC-SHA256 request signature; compatible with GitHub-style webhook consumers | None                                              |
+| `Webhook`        | HTTP POST with optional HMAC-SHA256 request signature; compatible with GitHub-style webhook consumers | None                                              |
 | `S3`             | Uploads events as gzipped JSONL objects to S3-compatible storage; one upload per event or batch | `software.amazon.awssdk:s3`                       |
 | `Redis`          | Publishes events to a Redis Stream (`XADD`) with optional approximate MAXLEN trimming | `io.lettuce:lettuce-core`                         |
 
@@ -567,9 +567,9 @@ All sinks receive fan-out delivery. `IllegalArgumentException` and `IllegalState
 `Webhook` sink behavior:
 
 - Each event payload is sent as an HTTP POST body to `endpoint`.
-- If `secret` is non-empty, an HMAC-SHA256 signature is computed over the payload and added as `sha256=<hex>` in `signatureHeader` (default `X-Hub-Signature-256`).
+- If `secret` is non-null, an HMAC-SHA256 signature is computed over the payload and added as `sha256=<hex>` in `signatureHeader` (default `X-Hub-Signature-256`).
 - Any non-2xx response or network error surfaces as `IllegalStateException` (compatible with `RetryingObservabilitySink`).
-- `timeoutMillis` governs JDK `HttpURLConnection` connect and read timeouts.
+- `timeoutMillis` governs JDK `HttpClient` connect and request timeouts.
 
 `S3` sink behavior:
 

--- a/api/observability.api
+++ b/api/observability.api
@@ -385,6 +385,7 @@ public final class io/github/aeshen/observability/config/sink/Slf4j : io/github/
 }
 
 public final class io/github/aeshen/observability/config/sink/Webhook : io/github/aeshen/observability/config/sink/SinkConfig {
+	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V

--- a/src/main/kotlin/io/github/aeshen/observability/config/sink/Webhook.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/config/sink/Webhook.kt
@@ -6,14 +6,14 @@ data class Webhook
     @JvmOverloads
     constructor(
         val endpoint: String,
-        val secret: String,
+        val secret: String? = null,
         val signatureHeader: String = "X-Hub-Signature-256",
         val headers: Map<String, String> = emptyMap(),
         val timeoutMillis: Long = 5_000,
     ) : SinkConfig {
         init {
             require(endpoint.isNotBlank()) { "endpoint must not be blank." }
-            require(secret.isNotBlank()) { "secret must not be blank." }
+            require(secret == null || secret.isNotBlank()) { "secret must not be blank when provided." }
             require(signatureHeader.isNotBlank()) { "signatureHeader must not be blank." }
             require(timeoutMillis > 0) { "timeoutMillis must be greater than 0." }
             require(headers.keys.none { it.isBlank() }) { "headers must not contain blank keys." }

--- a/src/main/kotlin/io/github/aeshen/observability/sink/impl/WebhookObservabilitySink.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/sink/impl/WebhookObservabilitySink.kt
@@ -18,7 +18,7 @@ private const val HMAC_SHA256 = "HmacSHA256"
 
 internal class WebhookObservabilitySink internal constructor(
     private val endpoint: URI,
-    private val signingKey: SecretKeySpec,
+    private val signingKey: SecretKeySpec?,
     private val signatureHeader: String,
     private val headers: Map<String, String>,
     private val timeoutMillis: Long,
@@ -26,7 +26,10 @@ internal class WebhookObservabilitySink internal constructor(
 ) : ObservabilitySink {
     constructor(config: Webhook) : this(
         endpoint = URI.create(config.endpoint),
-        signingKey = SecretKeySpec(config.secret.toByteArray(Charsets.UTF_8), HMAC_SHA256),
+        signingKey =
+            config.secret?.let {
+                SecretKeySpec(it.toByteArray(Charsets.UTF_8), HMAC_SHA256)
+            },
         signatureHeader = config.signatureHeader,
         headers = config.headers,
         timeoutMillis = config.timeoutMillis,
@@ -34,8 +37,8 @@ internal class WebhookObservabilitySink internal constructor(
     )
 
     override fun handle(event: EncodedEvent) {
-        val signature = sign(event.encoded)
-        val allHeaders = headers + mapOf(signatureHeader to signature)
+        val allHeaders =
+            signingKey?.let { headers + mapOf(signatureHeader to sign(event.encoded, it)) } ?: headers
 
         val requestBuilder =
             HttpRequest
@@ -51,7 +54,10 @@ internal class WebhookObservabilitySink internal constructor(
         }
     }
 
-    private fun sign(bytes: ByteArray): String {
+    private fun sign(
+        bytes: ByteArray,
+        signingKey: SecretKeySpec,
+    ): String {
         val mac = Mac.getInstance(HMAC_SHA256)
         mac.init(signingKey)
         return "sha256=" + mac.doFinal(bytes).joinToString("") { "%02x".format(it) }

--- a/src/test/kotlin/io/github/aeshen/observability/config/sink/WebhookConfigTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/config/sink/WebhookConfigTest.kt
@@ -7,9 +7,9 @@ import kotlin.test.assertFailsWith
 class WebhookConfigTest {
     @Test
     fun `valid config constructs successfully`() {
-        val config = Webhook(endpoint = "https://hooks.example.com/events", secret = "s3cr3t")
+        val config = Webhook(endpoint = "https://hooks.example.com/events")
         assertEquals("https://hooks.example.com/events", config.endpoint)
-        assertEquals("s3cr3t", config.secret)
+        assertEquals(null, config.secret)
         assertEquals("X-Hub-Signature-256", config.signatureHeader)
         assertEquals(emptyMap(), config.headers)
         assertEquals(5_000L, config.timeoutMillis)
@@ -30,9 +30,12 @@ class WebhookConfigTest {
     }
 
     @Test
-    fun `blank secret is rejected`() {
+    fun `blank secret is rejected when provided`() {
         assertFailsWith<IllegalArgumentException> {
             Webhook(endpoint = "https://hooks.example.com/events", secret = "")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            Webhook(endpoint = "https://hooks.example.com/events", secret = "  ")
         }
     }
 

--- a/src/test/kotlin/io/github/aeshen/observability/sink/impl/SinkImplementationsTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/sink/impl/SinkImplementationsTest.kt
@@ -42,6 +42,7 @@ class SinkImplementationsTest {
         val method: String,
         val path: String,
         val contentType: String?,
+        val signatureHeader: String?,
         val body: ByteArray,
     ) {
         override fun equals(other: Any?): Boolean {
@@ -53,6 +54,7 @@ class SinkImplementationsTest {
             if (method != other.method) return false
             if (path != other.path) return false
             if (contentType != other.contentType) return false
+            if (signatureHeader != other.signatureHeader) return false
             if (!body.contentEquals(other.body)) return false
 
             return true
@@ -62,6 +64,7 @@ class SinkImplementationsTest {
             var result = method.hashCode()
             result = 31 * result + path.hashCode()
             result = 31 * result + (contentType?.hashCode() ?: 0)
+            result = 31 * result + (signatureHeader?.hashCode() ?: 0)
             result = 31 * result + body.contentHashCode()
             return result
         }
@@ -175,6 +178,7 @@ class SinkImplementationsTest {
                             method = exchange.requestMethod,
                             path = exchange.requestURI.path,
                             contentType = exchange.requestHeaders.getFirst("Content-Type"),
+                            signatureHeader = exchange.requestHeaders.getFirst("X-Hub-Signature-256"),
                             body = exchange.requestBody.use { it.readBytes() },
                         ),
                     )
@@ -384,6 +388,7 @@ class SinkImplementationsTest {
                             method = exchange.requestMethod,
                             path = exchange.requestURI.path,
                             contentType = exchange.requestHeaders.getFirst("Content-Type"),
+                            signatureHeader = exchange.requestHeaders.getFirst("X-Hub-Signature-256"),
                             body = exchange.requestBody.use { it.readBytes() },
                         ),
                     )
@@ -412,8 +417,49 @@ class SinkImplementationsTest {
             mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
             val expectedSig = "sha256=" + mac.doFinal(payload).joinToString("") { "%02x".format(it) }
 
-            // Verify the captured request body matches what was signed
+            assertEquals(expectedSig, captured.signatureHeader)
             assertEquals(expectedSig, hmacHeader(captured.body, secret))
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `webhook sink skips signature header when secret is null`() {
+        val requests = LinkedBlockingQueue<CapturedHttpRequest>()
+        val server =
+            HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+                createContext("/hook") { exchange ->
+                    requests.offer(
+                        CapturedHttpRequest(
+                            method = exchange.requestMethod,
+                            path = exchange.requestURI.path,
+                            contentType = exchange.requestHeaders.getFirst("Content-Type"),
+                            signatureHeader = exchange.requestHeaders.getFirst("X-Hub-Signature-256"),
+                            body = exchange.requestBody.use { it.readBytes() },
+                        ),
+                    )
+                    exchange.sendResponseHeaders(204, -1)
+                    exchange.close()
+                }
+                start()
+            }
+
+        try {
+            val sink =
+                WebhookObservabilitySink(
+                    Webhook(
+                        endpoint = "http://127.0.0.1:${server.address.port}/hook",
+                        headers = mapOf("Content-Type" to "application/json"),
+                    ),
+                )
+
+            sink.handle(encoded("{\"event\":\"test\"}\n"))
+
+            val captured = requests.poll(5, TimeUnit.SECONDS)
+            assertNotNull(captured)
+            assertEquals("POST", captured.method)
+            assertEquals(null, captured.signatureHeader)
         } finally {
             server.stop(0)
         }


### PR DESCRIPTION
## What changed

- Changed Webhook.secret from required String to nullable String? = null, making unsigned delivery an explicit API choice for 2.0.
- Kept validation strict for provided secrets: non-null secrets must still be non-blank, so whitespace-only values are rejected as misconfiguration.
- Updated WebhookObservabilitySink to compute and attach the HMAC signature header only when a secret is present.
- Preserved signatureHeader as the existing non-blank config field and made it a no-op in unsigned mode rather than widening the API further.
- Added/updated config tests to cover the new default unsigned configuration and invalid blank provided secrets.
- Kept the existing signed webhook sink test and added an unsigned-path test asserting the signature header is omitted when secret == null.
- Updated README.md to document optional webhook signing, show the nullable opt-out behavior, and correct the timeout wording to match the HttpClient implementation.
- Updated CHANGELOG.md to record the new unsigned-delivery behavior and call out the nullable Webhook.secret API change.
- Refreshed api/observability.api so the binary compatibility snapshot reflects the new Webhook(endpoint) overload and nullable-secret signature shape.

Closing: #40

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [x] Built-in sinks / decorators / providers
- [x] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [ ] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`)
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [x] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [x] Added/updated tests
- [x] Ran `./gradlew test`
- [ ] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew ktlintCheck`
- [x] Ran `./gradlew detekt`
- [ ] Security scan status checked when the change affects dependencies or release surfaces
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [ ] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [ ] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [ ] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [x] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [x] Updated `CHANGELOG.md` (if needed)
- [x] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
