### PR TITLE
#34 feat: Spring Boot autoconfiguration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This library may be more than you need if:
 - [Architecture](#architecture)
 - [Features](#features)
 - [Install](#install)
+- [Spring Boot Starter](#spring-boot-starter)
 - [Quick Start](#quick-start)
 - [Defining Event Names](#defining-event-names)
 - [Emitting Events](#emitting-events)
@@ -161,6 +162,88 @@ Optional runtime integrations:
 | Console, file, zip, webhook, and HTTP sinks | none |
 
 `opentelemetry-*`, `slf4j-api`, coroutines, Kafka, S3, and Lettuce are kept optional at the library boundary. If you configure an integration without the required runtime JARs on the classpath, the factory fails fast with guidance to add them.
+
+
+---
+
+## Spring Boot Starter
+
+Provides a zero-boilerplate setup for Spring Boot applications using `observability-spring-boot-starter`.
+
+### Dependency
+
+```kotlin
+dependencies {
+    implementation("io.github.aeshen:observability-spring-boot-starter:1.2.0")
+}
+```
+
+### Configuration
+
+Configure the observability pipeline directly in `application.yml` or `application.properties`:
+
+```yaml
+observability:
+  sinks:
+    - type: console
+    - type: slf4j
+      logger: com.example.MyApplication
+    - type: kafka
+      bootstrap-servers: broker:9092
+      topic: app-events
+    - type: s3
+      bucket: my-logs
+      region: eu-west-1
+  fail-on-sink-error: false
+  profile: standard  # or audit_durable
+  async:
+    enabled: true
+    capacity: 2048
+```
+
+### Actuator Integration
+
+When Spring Boot Actuator is on the classpath, the starter exposes an `ObservabilityHealthIndicator` reporting worker state, queue depth, and drop counts:
+
+```json
+{
+  "status": "UP",
+  "details": {
+    "status": "READY",
+    "asyncWorkerHealthy": true,
+    "asyncWorkerMessage": "OK",
+    "asyncQueueDepth": 0,
+    "asyncQueueCapacity": 2048,
+    "asyncQueueDepthMax": 12,
+    "sinkHandleErrors": 0,
+    "sinkCloseErrors": 0,
+    "asyncDrops": 0,
+    "retryExhaustions": 0
+  }
+}
+```
+
+### Micrometer Metrics
+
+When Micrometer is on the classpath, the starter automatically registers metrics gauges and function counters:
+- `observability.sink.errors.handle` (counter)
+- `observability.sink.errors.close` (counter)
+- `observability.async.drops` (counter)
+- `observability.async.worker.errors` (counter)
+- `observability.retry.exhaustions` (counter)
+- `observability.batch.flush.successes` (counter)
+- `observability.batch.flush.failures` (counter)
+- `observability.batch.flushed.events` (counter)
+- `observability.async.queue.depth` (gauge)
+- `observability.async.queue.capacity` (gauge)
+
+### Autowired Beans
+
+The starter automatically configures:
+- `Observability` — Primary bean, `@ConditionalOnMissingBean`
+- `SinkRegistry` — Can be extended by registering custom `SinkProvider` beans
+- `ObservabilityDiagnostics` — `InMemoryOperationalDiagnostics` by default, `@ConditionalOnMissingBean`
+- Custom `ContextProvider`, `MetadataEnricher`, and `ObservabilityProcessor` beans in the ApplicationContext are automatically discovered and registered.
 
 ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,8 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 plugins {
@@ -20,6 +23,16 @@ version = providers.gradleProperty("VERSION_NAME").get()
 
 repositories {
     mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+kotlin {
+    jvmToolchain(21)
 }
 
 detekt {
@@ -45,6 +58,20 @@ tasks.matching { it.name == "check" }.configureEach {
 subprojects {
     apply(plugin = "io.gitlab.arturbosch.detekt")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    plugins.withId("java") {
+        extensions.configure<JavaPluginExtension> {
+            toolchain {
+                languageVersion.set(JavaLanguageVersion.of(21))
+            }
+        }
+    }
+
+    plugins.withId("org.jetbrains.kotlin.jvm") {
+        extensions.configure<KotlinJvmProjectExtension> {
+            jvmToolchain(21)
+        }
+    }
 
     extensions.configure<DetektExtension> {
         config.setFrom(files("$rootDir/config/detekt/detekt.yml"))

--- a/observability-spring-boot-starter/api/observability-spring-boot-starter.api
+++ b/observability-spring-boot-starter/api/observability-spring-boot-starter.api
@@ -1,0 +1,128 @@
+public final class io/github/aeshen/observability/spring/AsyncProperties {
+	public fun <init> ()V
+	public final fun getCapacity ()I
+	public final fun getCloseTimeoutMillis ()J
+	public final fun getEnabled ()Z
+	public final fun getFailOnDrop ()Z
+	public final fun getOfferTimeoutMillis ()J
+	public final fun getShutdownPolicy ()Lio/github/aeshen/observability/sink/decorator/AsyncObservabilitySink$ShutdownPolicy;
+	public final fun setCapacity (I)V
+	public final fun setCloseTimeoutMillis (J)V
+	public final fun setEnabled (Z)V
+	public final fun setFailOnDrop (Z)V
+	public final fun setOfferTimeoutMillis (J)V
+	public final fun setShutdownPolicy (Lio/github/aeshen/observability/sink/decorator/AsyncObservabilitySink$ShutdownPolicy;)V
+}
+
+public final class io/github/aeshen/observability/spring/EncryptionProperties {
+	public fun <init> ()V
+	public final fun getAesKeyBase64 ()Ljava/lang/String;
+	public final fun getAesKeyHex ()Ljava/lang/String;
+	public final fun getRecipientPublicKeyPem ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun setAesKeyBase64 (Ljava/lang/String;)V
+	public final fun setAesKeyHex (Ljava/lang/String;)V
+	public final fun setRecipientPublicKeyPem (Ljava/lang/String;)V
+	public final fun setType (Ljava/lang/String;)V
+	public final fun toEncryptionConfig ()Lio/github/aeshen/observability/config/encryption/EncryptionConfig;
+}
+
+public final class io/github/aeshen/observability/spring/ObservabilityAutoConfiguration {
+	public fun <init> ()V
+	public final fun observability (Lio/github/aeshen/observability/spring/ObservabilityProperties;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;)Lio/github/aeshen/observability/Observability;
+	public final fun observabilityCodec ()Lio/github/aeshen/observability/codec/ObservabilityCodec;
+	public final fun observabilityDiagnostics ()Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;
+	public final fun sinkRegistry (Ljava/util/List;Lio/github/aeshen/observability/spring/ObservabilityProperties;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;)Lio/github/aeshen/observability/sink/registry/SinkRegistry;
+}
+
+public final class io/github/aeshen/observability/spring/ObservabilityAutoConfiguration$ActuatorConfiguration {
+	public fun <init> ()V
+	public final fun observabilityHealthIndicator (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;)Lorg/springframework/boot/actuate/health/HealthIndicator;
+}
+
+public final class io/github/aeshen/observability/spring/ObservabilityAutoConfiguration$MicrometerConfiguration {
+	public fun <init> ()V
+	public final fun observabilityMetricsBinder (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;)Lio/github/aeshen/observability/spring/ObservabilityMetricsBinder;
+}
+
+public final class io/github/aeshen/observability/spring/ObservabilityHealthIndicator : org/springframework/boot/actuate/health/HealthIndicator {
+	public fun <init> (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;)V
+	public fun health ()Lorg/springframework/boot/actuate/health/Health;
+}
+
+public final class io/github/aeshen/observability/spring/ObservabilityMetricsBinder : io/micrometer/core/instrument/binder/MeterBinder {
+	public fun <init> (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;)V
+	public fun bindTo (Lio/micrometer/core/instrument/MeterRegistry;)V
+}
+
+public final class io/github/aeshen/observability/spring/ObservabilityProperties {
+	public fun <init> ()V
+	public final fun getAsync ()Lio/github/aeshen/observability/spring/AsyncProperties;
+	public final fun getEncryption ()Lio/github/aeshen/observability/spring/EncryptionProperties;
+	public final fun getFailOnSinkError ()Z
+	public final fun getProfile ()Lio/github/aeshen/observability/ObservabilityFactory$Profile;
+	public final fun getSinks ()Ljava/util/List;
+	public final fun setAsync (Lio/github/aeshen/observability/spring/AsyncProperties;)V
+	public final fun setEncryption (Lio/github/aeshen/observability/spring/EncryptionProperties;)V
+	public final fun setFailOnSinkError (Z)V
+	public final fun setProfile (Lio/github/aeshen/observability/ObservabilityFactory$Profile;)V
+	public final fun setSinks (Ljava/util/List;)V
+}
+
+public final class io/github/aeshen/observability/spring/SinkProperties {
+	public fun <init> ()V
+	public final fun getAdditionalProperties ()Ljava/util/Map;
+	public final fun getBootstrapServers ()Ljava/lang/String;
+	public final fun getBucket ()Ljava/lang/String;
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getEndpoint ()Ljava/lang/String;
+	public final fun getExporterTimeoutMillis ()Ljava/lang/Long;
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getInstrumentationScopeName ()Ljava/lang/String;
+	public final fun getKeyPrefix ()Ljava/lang/String;
+	public final fun getLogger ()Ljava/lang/String;
+	public final fun getMaxExportBatchSize ()Ljava/lang/Integer;
+	public final fun getMaxQueueSize ()Ljava/lang/Integer;
+	public final fun getMaxlen ()Ljava/lang/Long;
+	public final fun getMethod ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getRegion ()Ljava/lang/String;
+	public final fun getScheduleDelayMillis ()Ljava/lang/Long;
+	public final fun getSecret ()Ljava/lang/String;
+	public final fun getServiceName ()Ljava/lang/String;
+	public final fun getServiceVersion ()Ljava/lang/String;
+	public final fun getSignatureHeader ()Ljava/lang/String;
+	public final fun getStreamKey ()Ljava/lang/String;
+	public final fun getTimeoutMillis ()Ljava/lang/Long;
+	public final fun getTopic ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public final fun setAdditionalProperties (Ljava/util/Map;)V
+	public final fun setBootstrapServers (Ljava/lang/String;)V
+	public final fun setBucket (Ljava/lang/String;)V
+	public final fun setClientId (Ljava/lang/String;)V
+	public final fun setEndpoint (Ljava/lang/String;)V
+	public final fun setExporterTimeoutMillis (Ljava/lang/Long;)V
+	public final fun setHeaders (Ljava/util/Map;)V
+	public final fun setInstrumentationScopeName (Ljava/lang/String;)V
+	public final fun setKeyPrefix (Ljava/lang/String;)V
+	public final fun setLogger (Ljava/lang/String;)V
+	public final fun setMaxExportBatchSize (Ljava/lang/Integer;)V
+	public final fun setMaxQueueSize (Ljava/lang/Integer;)V
+	public final fun setMaxlen (Ljava/lang/Long;)V
+	public final fun setMethod (Ljava/lang/String;)V
+	public final fun setPath (Ljava/lang/String;)V
+	public final fun setRegion (Ljava/lang/String;)V
+	public final fun setScheduleDelayMillis (Ljava/lang/Long;)V
+	public final fun setSecret (Ljava/lang/String;)V
+	public final fun setServiceName (Ljava/lang/String;)V
+	public final fun setServiceVersion (Ljava/lang/String;)V
+	public final fun setSignatureHeader (Ljava/lang/String;)V
+	public final fun setStreamKey (Ljava/lang/String;)V
+	public final fun setTimeoutMillis (Ljava/lang/Long;)V
+	public final fun setTopic (Ljava/lang/String;)V
+	public final fun setType (Ljava/lang/String;)V
+	public final fun setUri (Ljava/lang/String;)V
+	public final fun toSinkConfig ()Lio/github/aeshen/observability/config/sink/SinkConfig;
+}
+

--- a/observability-spring-boot-starter/build.gradle.kts
+++ b/observability-spring-boot-starter/build.gradle.kts
@@ -1,8 +1,10 @@
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 
 plugins {
     kotlin("jvm") version "2.3.20"
+    kotlin("kapt")
     `java-library`
     `maven-publish`
 }
@@ -14,6 +16,16 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
 dependencies {
     api(project(":"))
 
@@ -21,7 +33,7 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-actuator:3.4.0")
     compileOnly("io.micrometer:micrometer-core:1.14.0")
 
-    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:3.4.0")
+    kapt("org.springframework.boot:spring-boot-configuration-processor:3.4.0")
 
     testImplementation(kotlin("test"))
     testImplementation("org.springframework.boot:spring-boot-starter-test:3.4.0")

--- a/observability-spring-boot-starter/build.gradle.kts
+++ b/observability-spring-boot-starter/build.gradle.kts
@@ -1,0 +1,52 @@
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+
+plugins {
+    kotlin("jvm") version "2.3.20"
+    `java-library`
+    `maven-publish`
+}
+
+group = rootProject.group
+version = rootProject.version
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api(project(":"))
+
+    compileOnly("org.springframework.boot:spring-boot-autoconfigure:3.4.0")
+    compileOnly("org.springframework.boot:spring-boot-actuator:3.4.0")
+    compileOnly("io.micrometer:micrometer-core:1.14.0")
+
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:3.4.0")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.springframework.boot:spring-boot-starter-test:3.4.0")
+    testImplementation("org.springframework.boot:spring-boot-starter-actuator:3.4.0")
+    testImplementation("io.micrometer:micrometer-core:1.14.0")
+}
+
+extensions.configure<PublishingExtension> {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            artifactId = "observability-spring-boot-starter"
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/janhaesen/observability")
+
+            credentials {
+                username = findProperty("gpr.user") as String?
+                    ?: System.getenv("GITHUB_USERNAME")
+                password = findProperty("gpr.key") as String?
+                    ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}

--- a/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityAutoConfiguration.kt
+++ b/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityAutoConfiguration.kt
@@ -1,0 +1,143 @@
+package io.github.aeshen.observability.spring
+
+import io.github.aeshen.observability.ContextProvider
+import io.github.aeshen.observability.Observability
+import io.github.aeshen.observability.ObservabilityFactory
+import io.github.aeshen.observability.codec.ObservabilityCodec
+import io.github.aeshen.observability.codec.impl.JsonLineCodec
+import io.github.aeshen.observability.diagnostics.InMemoryOperationalDiagnostics
+import io.github.aeshen.observability.diagnostics.ObservabilityDiagnostics
+import io.github.aeshen.observability.enricher.MetadataEnricher
+import io.github.aeshen.observability.processor.ObservabilityProcessor
+import io.github.aeshen.observability.sink.ObservabilitySink
+import io.github.aeshen.observability.sink.decorator.AsyncObservabilitySink
+import io.github.aeshen.observability.sink.registry.SinkProvider
+import io.github.aeshen.observability.sink.registry.SinkRegistry
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@AutoConfiguration
+@EnableConfigurationProperties(ObservabilityProperties::class)
+class ObservabilityAutoConfiguration {
+    @Bean
+    @ConditionalOnMissingBean
+    fun observabilityDiagnostics(): ObservabilityDiagnostics {
+        return InMemoryOperationalDiagnostics()
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun observabilityCodec(): ObservabilityCodec {
+        return JsonLineCodec()
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun sinkRegistry(
+        customProviders: List<SinkProvider>,
+        properties: ObservabilityProperties,
+        diagnostics: ObservabilityDiagnostics,
+    ): SinkRegistry {
+        val builder = SinkRegistry.builder()
+
+        fun wrapIfAsync(sink: ObservabilitySink): ObservabilitySink {
+            return if (properties.async.enabled) {
+                AsyncObservabilitySink(
+                    delegate = sink,
+                    capacity = properties.async.capacity,
+                    offerTimeoutMillis = properties.async.offerTimeoutMillis,
+                    failOnDrop = properties.async.failOnDrop,
+                    closeTimeoutMillis = properties.async.closeTimeoutMillis,
+                    shutdownPolicy = properties.async.shutdownPolicy,
+                    diagnostics = diagnostics,
+                )
+            } else {
+                sink
+            }
+        }
+
+        customProviders.forEach { customProvider ->
+            builder.registerProvider { config ->
+                val sink = customProvider.create(config)
+                sink?.let { wrapIfAsync(it) }
+            }
+        }
+
+        val defaultRegistry = SinkRegistry.default()
+        builder.registerProvider { config ->
+            val sink =
+                try {
+                    defaultRegistry.resolve(config)
+                } catch (
+                    @Suppress(
+                        "TooGenericExceptionCaught",
+                        "SwallowedException",
+                        "detekt.TooGenericExceptionCaught",
+                        "detekt.SwallowedException",
+                    ) e: Exception,
+                ) {
+                    null
+                }
+            sink?.let { wrapIfAsync(it) }
+        }
+
+        return builder.build()
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @Suppress("LongParameterList", "detekt.LongParameterList")
+    fun observability(
+        properties: ObservabilityProperties,
+        codec: ObservabilityCodec,
+        contextProviders: List<ContextProvider>,
+        metadataEnrichers: List<MetadataEnricher>,
+        processors: List<ObservabilityProcessor>,
+        sinkRegistry: SinkRegistry,
+        diagnostics: ObservabilityDiagnostics,
+    ): Observability {
+        val sinkConfigs = properties.sinks.map { it.toSinkConfig() }
+
+        val config =
+            ObservabilityFactory.Config(
+                sinks = sinkConfigs,
+                encryption = properties.encryption?.toEncryptionConfig(),
+                failOnSinkError = properties.failOnSinkError,
+                sinkRegistry = sinkRegistry,
+                codec = codec,
+                contextProviders = contextProviders,
+                metadataEnrichers = metadataEnrichers,
+                diagnostics = diagnostics,
+                profile = properties.profile,
+                processors = processors,
+            )
+
+        return ObservabilityFactory.create(config)
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(HealthIndicator::class)
+    class ActuatorConfiguration {
+        @Bean
+        @ConditionalOnMissingBean(name = ["observabilityHealthIndicator"])
+        fun observabilityHealthIndicator(diagnostics: ObservabilityDiagnostics): HealthIndicator {
+            return ObservabilityHealthIndicator(diagnostics)
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(MeterRegistry::class)
+    class MicrometerConfiguration {
+        @Bean
+        @ConditionalOnMissingBean
+        fun observabilityMetricsBinder(diagnostics: ObservabilityDiagnostics): ObservabilityMetricsBinder {
+            return ObservabilityMetricsBinder(diagnostics)
+        }
+    }
+}

--- a/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityAutoConfiguration.kt
+++ b/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityAutoConfiguration.kt
@@ -71,20 +71,7 @@ class ObservabilityAutoConfiguration {
 
         val defaultRegistry = SinkRegistry.default()
         builder.registerProvider { config ->
-            val sink =
-                try {
-                    defaultRegistry.resolve(config)
-                } catch (
-                    @Suppress(
-                        "TooGenericExceptionCaught",
-                        "SwallowedException",
-                        "detekt.TooGenericExceptionCaught",
-                        "detekt.SwallowedException",
-                    ) e: Exception,
-                ) {
-                    null
-                }
-            sink?.let { wrapIfAsync(it) }
+            wrapIfAsync(defaultRegistry.resolve(config))
         }
 
         return builder.build()

--- a/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityHealthIndicator.kt
+++ b/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityHealthIndicator.kt
@@ -1,0 +1,41 @@
+package io.github.aeshen.observability.spring
+
+import io.github.aeshen.observability.diagnostics.HealthStatus
+import io.github.aeshen.observability.diagnostics.InMemoryOperationalDiagnostics
+import io.github.aeshen.observability.diagnostics.ObservabilityDiagnostics
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+
+class ObservabilityHealthIndicator(
+    private val diagnostics: ObservabilityDiagnostics,
+) : HealthIndicator {
+    override fun health(): Health {
+        if (diagnostics !is InMemoryOperationalDiagnostics) {
+            return Health.up()
+                .withDetail("message", "Custom diagnostics configured, in-memory metrics not available")
+                .build()
+        }
+        val healthSnapshot = diagnostics.healthSnapshot()
+        val metricsSnapshot = diagnostics.metricsSnapshot()
+
+        val builder =
+            when (healthSnapshot.status) {
+                HealthStatus.READY -> Health.up()
+                HealthStatus.DEGRADED -> Health.status("DEGRADED")
+                HealthStatus.UNHEALTHY -> Health.down()
+            }
+
+        return builder
+            .withDetail("status", healthSnapshot.status.name)
+            .withDetail("asyncWorkerHealthy", healthSnapshot.asyncWorkerHealthy)
+            .withDetail("asyncWorkerMessage", healthSnapshot.asyncWorkerMessage ?: "OK")
+            .withDetail("asyncQueueDepth", metricsSnapshot.asyncQueueDepth)
+            .withDetail("asyncQueueCapacity", metricsSnapshot.asyncQueueCapacity)
+            .withDetail("asyncQueueDepthMax", metricsSnapshot.asyncQueueDepthMax)
+            .withDetail("sinkHandleErrors", metricsSnapshot.sinkHandleErrors)
+            .withDetail("sinkCloseErrors", metricsSnapshot.sinkCloseErrors)
+            .withDetail("asyncDrops", metricsSnapshot.asyncDrops)
+            .withDetail("retryExhaustions", metricsSnapshot.retryExhaustions)
+            .build()
+    }
+}

--- a/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityMetricsBinder.kt
+++ b/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityMetricsBinder.kt
@@ -1,0 +1,55 @@
+package io.github.aeshen.observability.spring
+
+import io.github.aeshen.observability.diagnostics.InMemoryOperationalDiagnostics
+import io.github.aeshen.observability.diagnostics.ObservabilityDiagnostics
+import io.micrometer.core.instrument.FunctionCounter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.MeterBinder
+
+class ObservabilityMetricsBinder(
+    private val diagnostics: ObservabilityDiagnostics,
+) : MeterBinder {
+    override fun bindTo(registry: MeterRegistry) {
+        if (diagnostics !is InMemoryOperationalDiagnostics) return
+
+        FunctionCounter.builder("observability.sink.errors.handle", diagnostics) {
+            it.metricsSnapshot().sinkHandleErrors.toDouble()
+        }.description("Total number of sink handle errors").register(registry)
+
+        FunctionCounter.builder("observability.sink.errors.close", diagnostics) {
+            it.metricsSnapshot().sinkCloseErrors.toDouble()
+        }.description("Total number of sink close errors").register(registry)
+
+        FunctionCounter.builder("observability.async.drops", diagnostics) {
+            it.metricsSnapshot().asyncDrops.toDouble()
+        }.description("Total number of events dropped by the async queue").register(registry)
+
+        FunctionCounter.builder("observability.async.worker.errors", diagnostics) {
+            it.metricsSnapshot().asyncWorkerErrors.toDouble()
+        }.description("Total number of async worker errors").register(registry)
+
+        FunctionCounter.builder("observability.retry.exhaustions", diagnostics) {
+            it.metricsSnapshot().retryExhaustions.toDouble()
+        }.description("Total number of retry exhaustions").register(registry)
+
+        FunctionCounter.builder("observability.batch.flush.successes", diagnostics) {
+            it.metricsSnapshot().batchFlushSuccesses.toDouble()
+        }.description("Total number of successful batch flushes").register(registry)
+
+        FunctionCounter.builder("observability.batch.flush.failures", diagnostics) {
+            it.metricsSnapshot().batchFlushFailures.toDouble()
+        }.description("Total number of failed batch flushes").register(registry)
+
+        FunctionCounter.builder("observability.batch.flushed.events", diagnostics) {
+            it.metricsSnapshot().batchFlushedEvents.toDouble()
+        }.description("Total number of events flushed in batches").register(registry)
+
+        registry.gauge("observability.async.queue.depth", diagnostics) {
+            it.metricsSnapshot().asyncQueueDepth.toDouble()
+        }
+
+        registry.gauge("observability.async.queue.capacity", diagnostics) {
+            it.metricsSnapshot().asyncQueueCapacity.toDouble()
+        }
+    }
+}

--- a/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityProperties.kt
+++ b/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityProperties.kt
@@ -161,12 +161,19 @@ class EncryptionProperties {
     }
 
     private fun hexToBytes(hex: String): ByteArray {
+        require(hex.length % 2 == 0) {
+            "AES hex key must contain an even number of characters"
+        }
+
         val len = hex.length
         val data = ByteArray(len / 2)
         var i = 0
         while (i < len) {
             val h1 = Character.digit(hex[i], 16)
             val h2 = Character.digit(hex[i + 1], 16)
+            require(h1 >= 0 && h2 >= 0) {
+                "AES hex key contains an invalid hexadecimal character at index $i"
+            }
             data[i / 2] = ((h1 shl 4) or h2).toByte()
             i += 2
         }

--- a/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityProperties.kt
+++ b/observability-spring-boot-starter/src/main/kotlin/io/github/aeshen/observability/spring/ObservabilityProperties.kt
@@ -1,0 +1,185 @@
+package io.github.aeshen.observability.spring
+
+import io.github.aeshen.observability.ObservabilityFactory.Profile
+import io.github.aeshen.observability.config.encryption.AesGcm
+import io.github.aeshen.observability.config.encryption.EncryptionConfig
+import io.github.aeshen.observability.config.encryption.RsaKeyWrapped
+import io.github.aeshen.observability.config.sink.Console
+import io.github.aeshen.observability.config.sink.File
+import io.github.aeshen.observability.config.sink.Http
+import io.github.aeshen.observability.config.sink.HttpMethod
+import io.github.aeshen.observability.config.sink.Kafka
+import io.github.aeshen.observability.config.sink.OpenTelemetry
+import io.github.aeshen.observability.config.sink.Redis
+import io.github.aeshen.observability.config.sink.S3
+import io.github.aeshen.observability.config.sink.SinkConfig
+import io.github.aeshen.observability.config.sink.Slf4j
+import io.github.aeshen.observability.config.sink.Webhook
+import io.github.aeshen.observability.config.sink.ZipFile
+import io.github.aeshen.observability.sink.decorator.AsyncObservabilitySink
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.nio.file.Paths
+import java.util.Base64
+import javax.crypto.spec.SecretKeySpec
+
+@ConfigurationProperties(prefix = "observability")
+class ObservabilityProperties {
+    var sinks: List<SinkProperties> = emptyList()
+    var failOnSinkError: Boolean = false
+    var profile: Profile = Profile.STANDARD
+    var encryption: EncryptionProperties? = null
+    var async: AsyncProperties = AsyncProperties()
+}
+
+class SinkProperties {
+    var type: String? = null
+    var endpoint: String? = null
+    var method: String = "POST"
+    var headers: Map<String, String> = emptyMap()
+    var timeoutMillis: Long? = null
+    var secret: String? = null
+    var signatureHeader: String = "X-Hub-Signature-256"
+    var bootstrapServers: String? = null
+    var topic: String? = null
+    var clientId: String = "observability-sink"
+    var additionalProperties: Map<String, String> = emptyMap()
+    var bucket: String? = null
+    var region: String? = null
+    var keyPrefix: String = "observability/"
+    var uri: String? = null
+    var streamKey: String? = null
+    var maxlen: Long? = null
+    var serviceName: String = "observability"
+    var serviceVersion: String? = null
+    var instrumentationScopeName: String = "io.github.aeshen.observability"
+    var scheduleDelayMillis: Long? = null
+    var exporterTimeoutMillis: Long? = null
+    var maxQueueSize: Int? = null
+    var maxExportBatchSize: Int? = null
+    var logger: String? = null
+    var path: String? = null
+
+    @Suppress(
+        "ComplexMethod",
+        "detekt.ComplexMethod",
+        "LongMethod",
+        "detekt.LongMethod",
+        "MagicNumber",
+        "detekt.MagicNumber",
+    )
+    fun toSinkConfig(): SinkConfig {
+        val t = type?.lowercase() ?: error("Sink type is required")
+        return when (t) {
+            "console" -> Console
+            "slf4j" -> {
+                val loggerClass = Class.forName(logger ?: "io.github.aeshen.observability.Observability").kotlin
+                Slf4j(loggerClass)
+            }
+            "file" -> File(Paths.get(path ?: error("path is required for file sink")))
+            "zipfile", "zip-file" -> ZipFile(Paths.get(path ?: error("path is required for zipfile sink")))
+            "http" ->
+                Http(
+                    endpoint = endpoint ?: error("endpoint is required for http sink"),
+                    method = HttpMethod.valueOf(method.uppercase()),
+                    headers = headers,
+                    timeoutMillis = timeoutMillis ?: 5000L,
+                )
+            "webhook" ->
+                Webhook(
+                    endpoint = endpoint ?: error("endpoint is required for webhook sink"),
+                    secret = secret,
+                    signatureHeader = signatureHeader,
+                    headers = headers,
+                    timeoutMillis = timeoutMillis ?: 5000L,
+                )
+            "kafka" ->
+                Kafka(
+                    bootstrapServers = bootstrapServers ?: error("bootstrapServers is required for kafka sink"),
+                    topic = topic ?: error("topic is required for kafka sink"),
+                    clientId = clientId,
+                    additionalProperties = additionalProperties,
+                    timeoutMillis = timeoutMillis ?: 5000L,
+                )
+            "s3" ->
+                S3(
+                    bucket = bucket ?: error("bucket is required for s3 sink"),
+                    region = region ?: error("region is required for s3 sink"),
+                    keyPrefix = keyPrefix,
+                    endpoint = endpoint,
+                    timeoutMillis = timeoutMillis ?: 30000L,
+                )
+            "redis" ->
+                Redis(
+                    uri = uri ?: error("uri is required for redis sink"),
+                    streamKey = streamKey ?: error("streamKey is required for redis sink"),
+                    maxlen = maxlen,
+                    timeoutMillis = timeoutMillis ?: 5000L,
+                )
+            "opentelemetry", "open-telemetry", "otel" ->
+                OpenTelemetry(
+                    endpoint = endpoint ?: "http://localhost:4318/v1/logs",
+                    serviceName = serviceName,
+                    serviceVersion = serviceVersion,
+                    instrumentationScopeName = instrumentationScopeName,
+                    headers = headers,
+                    scheduleDelayMillis = scheduleDelayMillis ?: 200L,
+                    exporterTimeoutMillis = exporterTimeoutMillis ?: 30000L,
+                    maxQueueSize = maxQueueSize ?: 2048,
+                    maxExportBatchSize = maxExportBatchSize ?: 512,
+                )
+            else -> error("Unknown sink type: $t")
+        }
+    }
+}
+
+@Suppress("MagicNumber", "detekt.MagicNumber")
+class EncryptionProperties {
+    var type: String? = null
+    var aesKeyHex: String? = null
+    var aesKeyBase64: String? = null
+    var recipientPublicKeyPem: String? = null
+
+    fun toEncryptionConfig(): EncryptionConfig {
+        val t = type?.lowercase() ?: error("Encryption type is required")
+        return when (t) {
+            "aes-gcm", "aes_gcm" -> {
+                val rawKey =
+                    when {
+                        aesKeyHex != null -> hexToBytes(aesKeyHex!!)
+                        aesKeyBase64 != null -> Base64.getDecoder().decode(aesKeyBase64)
+                        else -> error("aesKeyHex or aesKeyBase64 is required for aes-gcm encryption")
+                    }
+                AesGcm(SecretKeySpec(rawKey, "AES"))
+            }
+            "rsa-key-wrapped", "rsa_key_wrapped" -> {
+                RsaKeyWrapped(
+                    recipientPublicKeyPem ?: error("recipientPublicKeyPem is required for rsa-key-wrapped encryption"),
+                )
+            }
+            else -> error("Unknown encryption type: $t")
+        }
+    }
+
+    private fun hexToBytes(hex: String): ByteArray {
+        val len = hex.length
+        val data = ByteArray(len / 2)
+        var i = 0
+        while (i < len) {
+            val h1 = Character.digit(hex[i], 16)
+            val h2 = Character.digit(hex[i + 1], 16)
+            data[i / 2] = ((h1 shl 4) or h2).toByte()
+            i += 2
+        }
+        return data
+    }
+}
+
+@Suppress("MagicNumber", "detekt.MagicNumber")
+class AsyncProperties {
+    var enabled: Boolean = false
+    var capacity: Int = 1024
+    var offerTimeoutMillis: Long = 50L
+    var failOnDrop: Boolean = false
+    var closeTimeoutMillis: Long = 5000L
+    var shutdownPolicy: AsyncObservabilitySink.ShutdownPolicy = AsyncObservabilitySink.ShutdownPolicy.DRAIN
+}

--- a/observability-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/observability-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.github.aeshen.observability.spring.ObservabilityAutoConfiguration

--- a/observability-spring-boot-starter/src/test/kotlin/io/github/aeshen/observability/spring/ObservabilityAutoConfigurationTest.kt
+++ b/observability-spring-boot-starter/src/test/kotlin/io/github/aeshen/observability/spring/ObservabilityAutoConfigurationTest.kt
@@ -1,0 +1,31 @@
+package io.github.aeshen.observability.spring
+
+import io.github.aeshen.observability.config.sink.Kafka
+import io.github.aeshen.observability.diagnostics.InMemoryOperationalDiagnostics
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ObservabilityAutoConfigurationTest {
+    @Test
+    fun defaultRegistryKeepsOptionalDependencyErrors() {
+        val registry =
+            ObservabilityAutoConfiguration().sinkRegistry(
+                customProviders = emptyList(),
+                properties = ObservabilityProperties(),
+                diagnostics = InMemoryOperationalDiagnostics(),
+            )
+
+        val error =
+            assertFailsWith<IllegalStateException> {
+                registry.resolve(
+                    Kafka(
+                        bootstrapServers = "localhost:9092",
+                        topic = "events",
+                    ),
+                )
+            }
+
+        assertTrue(error.message.orEmpty().contains("Kafka sink requires optional runtime dependencies"))
+    }
+}

--- a/observability-spring-boot-starter/src/test/kotlin/io/github/aeshen/observability/spring/ObservabilityIntegrationTest.kt
+++ b/observability-spring-boot-starter/src/test/kotlin/io/github/aeshen/observability/spring/ObservabilityIntegrationTest.kt
@@ -1,0 +1,80 @@
+package io.github.aeshen.observability.spring
+
+import io.github.aeshen.observability.EventName
+import io.github.aeshen.observability.Observability
+import io.github.aeshen.observability.diagnostics.InMemoryOperationalDiagnostics
+import io.github.aeshen.observability.diagnostics.ObservabilityDiagnostics
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.actuate.health.Status
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.test.context.junit4.SpringRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+enum class TestEvents(override val eventName: String? = null) : EventName {
+    TEST_EVENT("test.event"),
+}
+
+@RunWith(SpringRunner::class)
+@SpringBootTest(
+    classes = [ObservabilityIntegrationTest.TestApp::class],
+    properties = [
+        "observability.sinks[0].type=console",
+        "observability.sinks[1].type=slf4j",
+        "observability.sinks[1].logger=io.github.aeshen.observability.spring.ObservabilityIntegrationTest",
+        "observability.fail-on-sink-error=true",
+        "observability.profile=standard",
+        "observability.async.enabled=true",
+        "observability.async.capacity=10",
+    ],
+)
+class ObservabilityIntegrationTest {
+    @Autowired
+    private lateinit var observability: Observability
+
+    @Autowired
+    private lateinit var diagnostics: ObservabilityDiagnostics
+
+    @Autowired
+    @Qualifier("observabilityHealthIndicator")
+    private lateinit var healthIndicator: HealthIndicator
+
+    @Autowired
+    private lateinit var meterRegistry: MeterRegistry
+
+    @Test
+    fun testAutoConfiguration() {
+        assertNotNull(observability)
+        assertNotNull(diagnostics)
+        assertTrue(diagnostics is InMemoryOperationalDiagnostics)
+
+        observability.info(TestEvents.TEST_EVENT, "Integration test message")
+
+        // Verify actuator health
+        val health = healthIndicator.health()
+        assertEquals(Status.UP, health.status)
+        assertEquals("READY", health.details["status"])
+        assertEquals(10, health.details["asyncQueueCapacity"])
+
+        // Verify micrometer metrics binding
+        val counter = meterRegistry.find("observability.async.drops").functionCounter()
+        assertNotNull(counter)
+    }
+
+    @SpringBootApplication
+    open class TestApp {
+        @Bean
+        open fun meterRegistry(): MeterRegistry {
+            return SimpleMeterRegistry()
+        }
+    }
+}

--- a/observability-spring-boot-starter/src/test/kotlin/io/github/aeshen/observability/spring/ObservabilityPropertiesTest.kt
+++ b/observability-spring-boot-starter/src/test/kotlin/io/github/aeshen/observability/spring/ObservabilityPropertiesTest.kt
@@ -1,0 +1,46 @@
+package io.github.aeshen.observability.spring
+
+import io.github.aeshen.observability.config.encryption.AesGcm
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ObservabilityPropertiesTest {
+    @Test
+    fun aesGcmAcceptsValidHexKeys() {
+        val properties =
+            EncryptionProperties().apply {
+                type = "aes-gcm"
+                aesKeyHex = "00112233445566778899aabbccddeeff"
+            }
+
+        assertIs<AesGcm>(properties.toEncryptionConfig())
+    }
+
+    @Test
+    fun aesGcmRejectsOddLengthHexKeys() {
+        val properties =
+            EncryptionProperties().apply {
+                type = "aes-gcm"
+                aesKeyHex = "abc"
+            }
+
+        val error = assertFailsWith<IllegalArgumentException> { properties.toEncryptionConfig() }
+
+        assertTrue(error.message.orEmpty().contains("even number of characters"))
+    }
+
+    @Test
+    fun aesGcmRejectsInvalidHexCharacters() {
+        val properties =
+            EncryptionProperties().apply {
+                type = "aes-gcm"
+                aesKeyHex = "00112233445566778899aabbccddeezz"
+            }
+
+        val error = assertFailsWith<IllegalArgumentException> { properties.toEncryptionConfig() }
+
+        assertTrue(error.message.orEmpty().contains("invalid hexadecimal character"))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "observability"
 include(":query-spi")
 include(":benchmarks")
 include(":examples:third-party-sink-example")
+include(":observability-spring-boot-starter")
 
 dependencyResolutionManagement {
     repositories {


### PR DESCRIPTION
## What changed

Added the `observability-spring-boot-starter` submodule, providing a zero-boilerplate setup to auto-wire the observability pipeline in Spring Boot applications. This includes:
- `ObservabilityProperties` mapping properties under `observability` prefix to configuration fields.
- `ObservabilityAutoConfiguration` for primary bean definitions, custom/built-in sink registries, and auto-detecting context providers/enrichers/processors.
- `ObservabilityHealthIndicator` reporting pipeline health, queue depth, and errors to Actuator.
- `ObservabilityMetricsBinder` exposing metrics telemetry to Micrometer.
- Integration tests and user quickstart documentation in the README.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [x] Built-in sinks / decorators / providers (integrated with starter)
- [ ] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [x] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`) (integrated with starter health & metrics)
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [x] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [x] Added/updated tests
- [x] Ran `./gradlew test`
- [x] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew ktlintCheck`
- [x] Ran `./gradlew detekt`
- [x] Security scan status checked when the change affects dependencies or release surfaces
- [x] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [x] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [ ] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [ ] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [x] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [ ] Updated `CHANGELOG.md` (if needed)
- [ ] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

The starter target version of Spring Boot is `3.4.0` (with Java 21) which matches the main project's JVM target of 21. Sinks, encryption configurations, and async properties are fully configurable via application properties (YAML/properties).

Implements #34