### PR TITLE
feat(sink): add dead-letter queue routing decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ The format is based on Keep a Changelog and the project follows Semantic Version
   - New `PersistentObservabilitySink` decorator that journals encoded events to disk before delegated delivery and replays unacknowledged events after restart.
   - Deterministic in-order replay with bounded retention via `maxPendingEvents` and `maxJournalBytes`.
   - Strict corruption handling: truncated journal tails are discarded on recovery, while other journal corruption fails fast.
+- **Dead-letter routing decorator** (issue #31):
+  - New `DlqObservabilitySink` decorator that routes eligible delegated-delivery failures to a fallback DLQ sink after retries or other synchronous handling are exhausted.
+  - New `ObservabilityDiagnostics.onDlqWrite` hook for successful dead-letter writes.
 
 ### Changed
 - Clarified delivery semantics and reliability documentation (issues #13, #14) to distinguish best-effort, strict, and durable delivery, to document `AUDIT_DURABLE` as an in-memory hardening profile rather than crash-safe durability, and to keep safe decorator composition explicit around the persistence boundary.
 - `Webhook.secret` now accepts `null` to disable HMAC signing, and unsigned webhook deliveries omit the signature header entirely (issue #40).
+- Built-in diagnostics snapshots now count DLQ writes as a reliability signal.
 
 ### Breaking changes
 - **Removed deprecated direct-sink factory overload** (issue #30):

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,9 +67,18 @@ _Avoid_: Recovery resend, best-effort resend
 A journaled event whose delegated delivery completed, allowing the persistent buffer to advance retention and cleanup.
 _Avoid_: Flushed event, processed event
 
+**Dead-letter routing**:
+Delivery behavior where a decorator writes an event to a designated **DLQ sink** after delegated delivery fails with an eligible exception.
+_Avoid_: Failure routing, fallback mirroring, durable delivery
+
+**DLQ sink**:
+The fallback sink that receives events from **dead-letter routing** so they can be inspected, replayed, or recovered later.
+_Avoid_: Retry sink, durable buffer, primary sink
+
 ## Flagged ambiguities
 
 - `AUDIT_DURABLE` is a public profile name, but it is not **durable delivery** in the glossary sense because it does not enable persistent buffering. Treat it as an audit-oriented profile that makes delivery stricter with retry and batching while keeping the canonical meaning of **durable delivery** reserved for restart-surviving persistence.
+- A **DLQ sink** is a fallback destination used after delegated delivery fails. It is not automatically **durable delivery**; it is only restart-safe if the configured DLQ sink itself persists events durably.
 
 ### Example dialogue
 
@@ -84,6 +93,10 @@ _Avoid_: Flushed event, processed event
 > **Developer:** And once the delegate sink accepts one of those events?
 >
 > **Domain expert:** It becomes an **acknowledged event**, so the buffer can clean it up.
+>
+> **Developer:** If retries are exhausted but a fallback file sink stores the event, what happened?
+>
+> **Domain expert:** That's **dead-letter routing** to a **DLQ sink**. It improved recoverability, but it did not turn the primary path into **durable delivery**.
 
 ## Where to look next
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This library may be more than you need if:
   - [BatchingObservabilitySink](#batchingobservabilitysink)
   - [PersistentObservabilitySink](#persistentobservabilitysink)
   - [RetryingObservabilitySink](#retryingobservabilitysink)
+  - [DlqObservabilitySink](#dlqobservabilitysink)
 - [Profiles](#profiles)
 - [Configure Encryption](#configure-encryption)
   - [AES-GCM with a fixed key](#aes-gcm-with-a-fixed-key)
@@ -110,13 +111,13 @@ Sinks (fan-out)      (write to Console, File, OpenTelemetry, …)
 - **Multiple sinks with fan-out** — Console, SLF4J, File (JSONL), ZipFile, OpenTelemetry OTLP, Kafka
 - **Optional encryption** — AES-GCM with a fixed key, or per-event data key wrapped with RSA-OAEP-256
 - **Sensitive-field filtering** — ordered allow/mask/remove processors for `context.*`, `metadata.*`, `message`, and `payload`
-- **Reliability decorators** — `AsyncObservabilitySink`, `BatchingObservabilitySink`, `PersistentObservabilitySink`, `RetryingObservabilitySink`
+- **Reliability decorators** — `AsyncObservabilitySink`, `BatchingObservabilitySink`, `PersistentObservabilitySink`, `RetryingObservabilitySink`, `DlqObservabilitySink`
 - **Profiles** — `STANDARD` (best-effort) or `AUDIT_DURABLE` (strict, retried, batched; not crash-safe by itself)
 - **Pluggable codec** — default JSONL, fully replaceable
 - **Sink SPI** — register custom sinks via `SinkConfig` + `SinkRegistry`
 - **Global context injection** — `ContextProvider` merges ambient context into every event
 - **Binary payload support** — attach opaque bytes to any event
-- **Diagnostics hooks** — `ObservabilityDiagnostics` for drops, retries, batch flushes, queue depth, worker health, and sink errors
+- **Diagnostics hooks** — `ObservabilityDiagnostics` for drops, retries, DLQ writes, batch flushes, queue depth, worker health, and sink errors
 - **Built-in operational collector** — `InMemoryOperationalDiagnostics` provides lightweight counters and health snapshots
 - **Binary compatibility tracking** — enforced via `binary-compatibility-validator`
 - **Audit query SPI** — `query-spi` module for backend-agnostic retrieval of audit records
@@ -759,6 +760,33 @@ val fixedRetrySink =
 
 `onRetryExhaustion` on `ObservabilityDiagnostics` is called before the final exception is rethrown.
 
+### DlqObservabilitySink
+
+Routes eligible delegated delivery failures to a fallback dead-letter sink:
+
+```kotlin
+import io.github.aeshen.observability.sink.decorator.DlqObservabilitySink
+import io.github.aeshen.observability.sink.decorator.RetryingObservabilitySink
+
+val sink =
+    DlqObservabilitySink(
+        delegate =
+            RetryingObservabilitySink(
+                delegate = myPrimarySink,
+                maxAttempts = 5,
+                diagnostics = myDiagnostics,
+            ),
+        dlq = myDlqSink,
+        diagnostics = myDiagnostics,
+    )
+```
+
+- `DlqObservabilitySink` catches the same handled sink failure types as the pipeline (`IllegalArgumentException` and `IllegalStateException`).
+- Successful dead-letter routing returns normally; the event has been handed to the configured DLQ sink instead of being dropped.
+- `onDlqWrite` on `ObservabilityDiagnostics` is called after the fallback sink accepts the event.
+- If the DLQ sink itself fails, the secondary failure is surfaced and the original delegated-delivery failure is attached as a suppressed exception.
+- A DLQ sink improves recoverability, but it is only **durable delivery** if the configured fallback sink persists events durably.
+
 ---
 
 ## Delivery semantics
@@ -1072,6 +1100,10 @@ val diagnostics =
         override fun onRetryExhaustion(event: EncodedEvent, attempts: Int, lastError: Exception) {
             logger.error("Retry exhausted after $attempts attempts: ${lastError.message}")
         }
+
+        override fun onDlqWrite(event: EncodedEvent, dlq: ObservabilitySink, originalError: Exception) {
+            metrics.increment("observability.dlq_write", "sink" to (dlq::class.simpleName ?: "unknown"))
+        }
     }
 
 val observability =
@@ -1093,6 +1125,7 @@ val observability =
 | `onAsyncWorkerState`  | Async worker health state changes                         |
 | `onBatchFlush`        | A batch is flushed (success or failure)                   |
 | `onRetryExhaustion`   | Retry limit exceeded; last error is rethrown              |
+| `onDlqWrite`          | An event is written to the configured DLQ sink            |
 
 ---
 

--- a/api/observability.api
+++ b/api/observability.api
@@ -486,6 +486,7 @@ public final class io/github/aeshen/observability/diagnostics/InMemoryOperationa
 	public fun onAsyncWorkerError (Ljava/lang/Exception;)V
 	public fun onAsyncWorkerState (ZLjava/lang/String;)V
 	public fun onBatchFlush (IJZLjava/lang/Exception;)V
+	public fun onDlqWrite (Lio/github/aeshen/observability/codec/EncodedEvent;Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/lang/Exception;)V
 	public fun onRetryExhaustion (Lio/github/aeshen/observability/codec/EncodedEvent;ILjava/lang/Exception;)V
 	public fun onSinkCloseError (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/lang/Exception;)V
 	public fun onSinkHandleError (Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/codec/EncodedEvent;Ljava/lang/Exception;)V
@@ -500,6 +501,7 @@ public abstract interface class io/github/aeshen/observability/diagnostics/Obser
 	public fun onAsyncWorkerState (ZLjava/lang/String;)V
 	public static synthetic fun onAsyncWorkerState$default (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;ZLjava/lang/String;ILjava/lang/Object;)V
 	public fun onBatchFlush (IJZLjava/lang/Exception;)V
+	public fun onDlqWrite (Lio/github/aeshen/observability/codec/EncodedEvent;Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/lang/Exception;)V
 	public fun onRetryExhaustion (Lio/github/aeshen/observability/codec/EncodedEvent;ILjava/lang/Exception;)V
 	public fun onSinkCloseError (Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/lang/Exception;)V
 	public fun onSinkHandleError (Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/codec/EncodedEvent;Ljava/lang/Exception;)V
@@ -515,6 +517,7 @@ public final class io/github/aeshen/observability/diagnostics/ObservabilityDiagn
 	public static fun onAsyncWorkerState (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;ZLjava/lang/String;)V
 	public static synthetic fun onAsyncWorkerState$default (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;ZLjava/lang/String;ILjava/lang/Object;)V
 	public static fun onBatchFlush (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;IJZLjava/lang/Exception;)V
+	public static fun onDlqWrite (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/codec/EncodedEvent;Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/lang/Exception;)V
 	public static fun onRetryExhaustion (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/codec/EncodedEvent;ILjava/lang/Exception;)V
 	public static fun onSinkCloseError (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/sink/ObservabilitySink;Ljava/lang/Exception;)V
 	public static fun onSinkHandleError (Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/codec/EncodedEvent;Ljava/lang/Exception;)V
@@ -538,12 +541,13 @@ public final class io/github/aeshen/observability/diagnostics/OperationalHealthS
 }
 
 public final class io/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot {
-	public fun <init> (JJJJJJJJJJIII)V
+	public fun <init> (JJJJJJJJJJJIII)V
 	public final fun component1 ()J
 	public final fun component10 ()J
-	public final fun component11 ()I
+	public final fun component11 ()J
 	public final fun component12 ()I
 	public final fun component13 ()I
+	public final fun component14 ()I
 	public final fun component2 ()J
 	public final fun component3 ()J
 	public final fun component4 ()J
@@ -552,8 +556,8 @@ public final class io/github/aeshen/observability/diagnostics/OperationalMetrics
 	public final fun component7 ()J
 	public final fun component8 ()J
 	public final fun component9 ()J
-	public final fun copy (JJJJJJJJJJIII)Lio/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot;
-	public static synthetic fun copy$default (Lio/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot;JJJJJJJJJJIIIILjava/lang/Object;)Lio/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot;
+	public final fun copy (JJJJJJJJJJJIII)Lio/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot;JJJJJJJJJJJIIIILjava/lang/Object;)Lio/github/aeshen/observability/diagnostics/OperationalMetricsSnapshot;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAsyncDrops ()J
 	public final fun getAsyncQueueCapacity ()I
@@ -566,6 +570,7 @@ public final class io/github/aeshen/observability/diagnostics/OperationalMetrics
 	public final fun getBatchFlushTotalCount ()J
 	public final fun getBatchFlushTotalElapsedMillis ()J
 	public final fun getBatchFlushedEvents ()J
+	public final fun getDlqWrites ()J
 	public final fun getRetryExhaustions ()J
 	public final fun getSinkCloseErrors ()J
 	public final fun getSinkHandleErrors ()J
@@ -800,6 +805,15 @@ public final class io/github/aeshen/observability/sink/decorator/BatchingObserva
 	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;IJ)V
 	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;IJLio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;)V
 	public synthetic fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;IJLio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public fun handle (Lio/github/aeshen/observability/codec/EncodedEvent;)V
+}
+
+public final class io/github/aeshen/observability/sink/decorator/DlqObservabilitySink : io/github/aeshen/observability/sink/ObservabilitySink {
+	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/sink/ObservabilitySink;)V
+	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;)V
+	public fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/sink/ObservabilitySink;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
 	public fun handle (Lio/github/aeshen/observability/codec/EncodedEvent;)V
 }

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -150,6 +150,7 @@ Processors are applied in the order provided. When encryption is enabled, custom
 - `PersistentObservabilitySink` journals events to disk before delegated delivery and replays unacknowledged events after restart.
 - `BatchCapableObservabilitySink` allows optimized batch delivery.
 - `RetryingObservabilitySink` retries transient failures using `BackoffStrategy`.
+- `DlqObservabilitySink` routes eligible delegated-delivery failures to a fallback dead-letter sink.
 
 `PersistentObservabilitySink` assumes its wrapped delegate is the acknowledgement boundary. It composes well with synchronous sinks and `RetryingObservabilitySink`, but not with `AsyncObservabilitySink` or `BatchingObservabilitySink` inside the persistence boundary because those decorators return before final delivery.
 

--- a/docs/spi-contract.md
+++ b/docs/spi-contract.md
@@ -68,6 +68,7 @@ ObservabilityFactory.create(
 - `onAsyncWorkerError`: async worker thread exceptions
 - `onBatchFlush`: batch delivery outcomes (size, elapsed, success/error)
 - `onRetryExhaustion`: retry limit exceeded with last error
+- `onDlqWrite`: event routed to the configured dead-letter sink
 
 Implement for monitoring, alerting, or metrics collection without side effects.
 

--- a/src/main/kotlin/io/github/aeshen/observability/diagnostics/InMemoryOperationalDiagnostics.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/diagnostics/InMemoryOperationalDiagnostics.kt
@@ -17,6 +17,7 @@ class InMemoryOperationalDiagnostics : ObservabilityDiagnostics {
     private val asyncDrops = AtomicLong(0)
     private val asyncWorkerErrors = AtomicLong(0)
     private val retryExhaustions = AtomicLong(0)
+    private val dlqWrites = AtomicLong(0)
     private val batchFlushSuccesses = AtomicLong(0)
     private val batchFlushFailures = AtomicLong(0)
     private val batchFlushTotalCount = AtomicLong(0)
@@ -101,6 +102,14 @@ class InMemoryOperationalDiagnostics : ObservabilityDiagnostics {
         retryExhaustions.incrementAndGet()
     }
 
+    override fun onDlqWrite(
+        event: EncodedEvent,
+        dlq: ObservabilitySink,
+        originalError: Exception,
+    ) {
+        dlqWrites.incrementAndGet()
+    }
+
     fun metricsSnapshot(): OperationalMetricsSnapshot =
         OperationalMetricsSnapshot(
             sinkHandleErrors = sinkHandleErrors.get(),
@@ -108,6 +117,7 @@ class InMemoryOperationalDiagnostics : ObservabilityDiagnostics {
             asyncDrops = asyncDrops.get(),
             asyncWorkerErrors = asyncWorkerErrors.get(),
             retryExhaustions = retryExhaustions.get(),
+            dlqWrites = dlqWrites.get(),
             batchFlushSuccesses = batchFlushSuccesses.get(),
             batchFlushFailures = batchFlushFailures.get(),
             batchFlushTotalCount = batchFlushTotalCount.get(),
@@ -139,6 +149,7 @@ class InMemoryOperationalDiagnostics : ObservabilityDiagnostics {
             sinkCloseErrors.get() > 0 ||
             asyncDrops.get() > 0 ||
             retryExhaustions.get() > 0 ||
+            dlqWrites.get() > 0 ||
             batchFlushFailures.get() > 0
 }
 
@@ -161,6 +172,7 @@ data class OperationalMetricsSnapshot(
     val asyncDrops: Long,
     val asyncWorkerErrors: Long,
     val retryExhaustions: Long,
+    val dlqWrites: Long,
     val batchFlushSuccesses: Long,
     val batchFlushFailures: Long,
     val batchFlushTotalCount: Long,

--- a/src/main/kotlin/io/github/aeshen/observability/diagnostics/ObservabilityDiagnostics.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/diagnostics/ObservabilityDiagnostics.kt
@@ -48,6 +48,12 @@ interface ObservabilityDiagnostics {
         lastError: Exception,
     ) {}
 
+    fun onDlqWrite(
+        event: EncodedEvent,
+        dlq: ObservabilitySink,
+        originalError: Exception,
+    ) {}
+
     companion object {
         @JvmField
         val NOOP: ObservabilityDiagnostics = object : ObservabilityDiagnostics {}

--- a/src/main/kotlin/io/github/aeshen/observability/sink/decorator/DlqObservabilitySink.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/sink/decorator/DlqObservabilitySink.kt
@@ -1,0 +1,95 @@
+package io.github.aeshen.observability.sink.decorator
+
+import io.github.aeshen.observability.codec.EncodedEvent
+import io.github.aeshen.observability.diagnostics.ObservabilityDiagnostics
+import io.github.aeshen.observability.sink.ObservabilitySink
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Decorator that routes eligible sink failures to a dead-letter sink.
+ */
+class DlqObservabilitySink
+    @JvmOverloads
+    constructor(
+        private val delegate: ObservabilitySink,
+        private val dlq: ObservabilitySink,
+        private val diagnostics: ObservabilityDiagnostics = ObservabilityDiagnostics.NOOP,
+        private val errorFilter: (Exception) -> Boolean = { true },
+    ) : ObservabilitySink {
+        private val open = AtomicBoolean(true)
+
+        override fun handle(event: EncodedEvent) {
+            check(open.get()) { "DlqObservabilitySink is closed." }
+
+            try {
+                delegate.handle(event)
+            } catch (e: IllegalArgumentException) {
+                routeToDlq(event, e)
+            } catch (e: IllegalStateException) {
+                routeToDlq(event, e)
+            }
+        }
+
+        override fun close() {
+            if (!open.compareAndSet(true, false)) {
+                return
+            }
+
+            val delegateError = closeSink(delegate)
+            val dlqError = closeSink(dlq)
+            if (delegateError == null) {
+                dlqError?.let { throw it }
+                return
+            }
+            if (dlqError == null) {
+                throw delegateError
+            }
+
+            delegateError.addSuppressed(dlqError)
+            throw delegateError
+        }
+
+        private fun routeToDlq(
+            event: EncodedEvent,
+            delegateError: Exception,
+        ) {
+            if (!errorFilter(delegateError)) {
+                throw delegateError
+            }
+
+            try {
+                dlq.handle(event)
+                diagnostics.onDlqWrite(event = event, dlq = dlq, originalError = delegateError)
+            } catch (dlqError: IOException) {
+                handleDlqFailure(event, delegateError, dlqError)
+            } catch (dlqError: IllegalArgumentException) {
+                handleDlqFailure(event, delegateError, dlqError)
+            } catch (dlqError: IllegalStateException) {
+                handleDlqFailure(event, delegateError, dlqError)
+            }
+        }
+
+        private fun closeSink(sink: ObservabilitySink): Exception? =
+            try {
+                sink.close()
+                null
+            } catch (e: IOException) {
+                e
+            } catch (e: IllegalArgumentException) {
+                e
+            } catch (e: IllegalStateException) {
+                e
+            }
+
+        private fun handleDlqFailure(
+            event: EncodedEvent,
+            delegateError: Exception,
+            dlqError: Exception,
+        ): Nothing {
+            diagnostics.onSinkHandleError(sink = dlq, event = event, error = dlqError)
+            throw IllegalStateException("Dead-letter routing failed after delegated delivery error.", dlqError).apply {
+                addSuppressed(delegateError)
+            }
+        }
+    }

--- a/src/test/kotlin/io/github/aeshen/observability/diagnostics/InMemoryOperationalDiagnosticsTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/diagnostics/InMemoryOperationalDiagnosticsTest.kt
@@ -32,6 +32,11 @@ class InMemoryOperationalDiagnosticsTest {
             attempts = 3,
             lastError = IllegalStateException("retry"),
         )
+        diagnostics.onDlqWrite(
+            sampleEvent(),
+            dlq = NoopSink,
+            originalError = IllegalStateException("delegate"),
+        )
 
         val snapshot = diagnostics.metricsSnapshot()
 
@@ -39,6 +44,7 @@ class InMemoryOperationalDiagnosticsTest {
         assertEquals(1, snapshot.sinkCloseErrors)
         assertEquals(1, snapshot.asyncDrops)
         assertEquals(1, snapshot.retryExhaustions)
+        assertEquals(1, snapshot.dlqWrites)
         assertEquals(1, snapshot.batchFlushSuccesses)
         assertEquals(1, snapshot.batchFlushFailures)
         assertEquals(2, snapshot.batchFlushTotalCount)
@@ -54,7 +60,7 @@ class InMemoryOperationalDiagnosticsTest {
     fun `collector health is degraded when reliability signals are present`() {
         val diagnostics = InMemoryOperationalDiagnostics()
 
-        diagnostics.onRetryExhaustion(sampleEvent(), attempts = 2, lastError = IllegalStateException("retry"))
+        diagnostics.onDlqWrite(sampleEvent(), dlq = NoopSink, originalError = IllegalStateException("delegate"))
 
         val health = diagnostics.healthSnapshot()
 

--- a/src/test/kotlin/io/github/aeshen/observability/sink/decorator/SinkDecoratorTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/sink/decorator/SinkDecoratorTest.kt
@@ -446,6 +446,151 @@ class RetryingObservabilitySinkTest {
     }
 }
 
+class DlqObservabilitySinkTest {
+    @Test
+    fun `routes eligible delegate failures to dlq and reports diagnostics`() {
+        val dlqEvents = mutableListOf<EncodedEvent>()
+        val routed = mutableListOf<String>()
+        val diagnostics =
+            object : ObservabilityDiagnostics {
+                override fun onDlqWrite(
+                    event: EncodedEvent,
+                    dlq: ObservabilitySink,
+                    originalError: Exception,
+                ) {
+                    routed += "${event.encoded.toString(Charsets.UTF_8)}:${originalError.message}"
+                }
+            }
+
+        val sink =
+            DlqObservabilitySink(
+                delegate =
+                    object : ObservabilitySink {
+                        override fun handle(event: EncodedEvent) = error("delegate-failed")
+                    },
+                dlq = CapturingSink(dlqEvents),
+                diagnostics = diagnostics,
+            )
+
+        sink.handle(sample("dlq"))
+
+        assertEquals(listOf("dlq"), dlqEvents.map { it.encoded.toString(Charsets.UTF_8) })
+        assertEquals(listOf("dlq:delegate-failed"), routed)
+    }
+
+    @Test
+    fun `rethrows delegate failures rejected by filter`() {
+        val dlqEvents = mutableListOf<EncodedEvent>()
+        val sink =
+            DlqObservabilitySink(
+                delegate =
+                    object : ObservabilitySink {
+                        override fun handle(event: EncodedEvent) = error("delegate-failed")
+                    },
+                dlq = CapturingSink(dlqEvents),
+                errorFilter = { false },
+            )
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                sink.handle(sample("skip"))
+            }
+
+        assertEquals("delegate-failed", failure.message)
+        assertTrue(dlqEvents.isEmpty())
+    }
+
+    @Test
+    fun `surfaces secondary dlq failure without recursion`() {
+        val secondaryErrors = mutableListOf<String>()
+        val diagnostics =
+            object : ObservabilityDiagnostics {
+                override fun onSinkHandleError(
+                    sink: ObservabilitySink,
+                    event: EncodedEvent,
+                    error: Exception,
+                ) {
+                    secondaryErrors += "${sink::class.simpleName}:${error.message}"
+                }
+            }
+
+        val dlq =
+            object : ObservabilitySink {
+                override fun handle(event: EncodedEvent) = error("dlq-failed")
+            }
+
+        val sink =
+            DlqObservabilitySink(
+                delegate =
+                    object : ObservabilitySink {
+                        override fun handle(event: EncodedEvent) = error("delegate-failed")
+                    },
+                dlq = dlq,
+                diagnostics = diagnostics,
+            )
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                sink.handle(sample("secondary"))
+            }
+
+        assertEquals("Dead-letter routing failed after delegated delivery error.", failure.message)
+        assertEquals("dlq-failed", failure.cause?.message)
+        assertEquals(1, secondaryErrors.size)
+        assertTrue(secondaryErrors.single().endsWith(":dlq-failed"))
+        assertEquals(listOf("delegate-failed"), failure.suppressed.mapNotNull { it.message })
+    }
+
+    @Test
+    fun `close closes both sinks and can be called repeatedly`() {
+        val closeCount = AtomicInteger(0)
+        val dlqCloseCount = AtomicInteger(0)
+        val sink =
+            DlqObservabilitySink(
+                delegate =
+                    object : ObservabilitySink {
+                        override fun handle(event: EncodedEvent) = Unit
+
+                        override fun close() {
+                            closeCount.incrementAndGet()
+                        }
+                    },
+                dlq =
+                    object : ObservabilitySink {
+                        override fun handle(event: EncodedEvent) = Unit
+
+                        override fun close() {
+                            dlqCloseCount.incrementAndGet()
+                        }
+                    },
+            )
+
+        sink.close()
+        sink.close()
+
+        assertEquals(1, closeCount.get())
+        assertEquals(1, dlqCloseCount.get())
+    }
+
+    @Test
+    fun `close rejects further writes deterministically`() {
+        val sink =
+            DlqObservabilitySink(
+                delegate = CapturingSink(mutableListOf()),
+                dlq = CapturingSink(mutableListOf()),
+            )
+
+        sink.close()
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                sink.handle(sample("after-close"))
+            }
+
+        assertEquals("DlqObservabilitySink is closed.", failure.message)
+    }
+}
+
 class DiagnosticsIntegrationTest {
     @Test
     fun `diagnostics tracks async drops, batch flushes, and retry outcomes`() {
@@ -480,6 +625,14 @@ class DiagnosticsIntegrationTest {
                 ) {
                     events.getOrPut("retry_exhaustion") { mutableListOf() } += "$attempts:${lastError.message}"
                 }
+
+                override fun onDlqWrite(
+                    event: EncodedEvent,
+                    dlq: ObservabilitySink,
+                    originalError: Exception,
+                ) {
+                    events.getOrPut("dlq_writes") { mutableListOf() } += originalError.message.orEmpty()
+                }
             }
 
         val handled = mutableListOf<EncodedEvent>()
@@ -501,6 +654,36 @@ class DiagnosticsIntegrationTest {
             "Batch flush should be reported as success with size 2",
         )
         sink.close()
+    }
+
+    @Test
+    fun `diagnostics tracks dlq writes`() {
+        val events = mutableMapOf<String, MutableList<String>>()
+        val diagnostics =
+            object : ObservabilityDiagnostics {
+                override fun onDlqWrite(
+                    event: EncodedEvent,
+                    dlq: ObservabilitySink,
+                    originalError: Exception,
+                ) {
+                    events.getOrPut("dlq_writes") { mutableListOf() } +=
+                        "${event.encoded.toString(Charsets.UTF_8)}:${originalError.message}"
+                }
+            }
+
+        val sink =
+            DlqObservabilitySink(
+                delegate =
+                    object : ObservabilitySink {
+                        override fun handle(event: EncodedEvent) = error("primary")
+                    },
+                dlq = CapturingSink(mutableListOf()),
+                diagnostics = diagnostics,
+            )
+
+        sink.handle(sample("dlq-event"))
+
+        assertEquals(listOf("dlq-event:primary"), events["dlq_writes"] ?: emptyList())
     }
 }
 


### PR DESCRIPTION
- Add DlqObservabilitySink to route eligible primary-sink failures to a configurable fallback sink after retry exhaustion or other synchronous delivery failures.
- Report successful DLQ writes through ObservabilityDiagnostics, expose the counter in InMemoryOperationalDiagnostics, and surface fallback failures with the original delivery failure preserved as suppressed.
- Document DLQ behavior, reliability semantics, extension support, and the public API.

Closes #31

## What changed

<!-- Briefly describe the change and why -->

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [x] Built-in sinks / decorators / providers
- [ ] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [x] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`)
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [x] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [x] Added/updated tests
- [x] Ran `./gradlew test`
- [ ] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew ktlintCheck`
- [x] Ran `./gradlew detekt`
- [ ] Security scan status checked when the change affects dependencies or release surfaces
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [x] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [x] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [x] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [x] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [x] Updated `CHANGELOG.md` (if needed)
- [x] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
