### PR TITLE
feat: add OpenAPI event-submission sidecar with durable audit delivery

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gradle
+**/build
+.idea
+.DS_Store

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,19 @@ jobs:
       - name: Build artifacts
         run: ./gradlew :jar :query-spi:jar --no-daemon
 
+      - name: Log in to GitHub Container Registry
+        run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+
+      - name: Build and publish sidecar image
+        run: |
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/observability-sidecar"
+          docker build -f sidecar/Dockerfile \
+            -t "${IMAGE}:${RELEASE_TAG}" \
+            -t "${IMAGE}:${GITHUB_SHA}" \
+            .
+          docker push "${IMAGE}:${RELEASE_TAG}"
+          docker push "${IMAGE}:${GITHUB_SHA}"
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ replay_pid*
 # --- Gradle ---
 .gradle/
 build/
+.openapi-generated/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on Keep a Changelog and the project follows Semantic Version
   - New `ObservabilityDiagnostics.onDlqWrite` hook for successful dead-letter writes.
 
 ### Changed
-- Clarified delivery semantics and reliability documentation (issues #13, #14) to distinguish best-effort, strict, and durable delivery, to document `AUDIT_DURABLE` as an in-memory hardening profile rather than crash-safe durability, and to keep safe decorator composition explicit around the persistence boundary.
+- `AUDIT_DURABLE` now requires `persistentBufferDirectory` and journals events before retrying delivery, making the profile restart-safe and at-least-once durable. This changes its operational requirements from in-memory hardening to durable local storage (issue #50).
 - `Webhook.secret` now accepts `null` to disable HMAC signing, and unsigned webhook deliveries omit the signature header entirely (issue #40).
 - Built-in diagnostics snapshots now count DLQ writes as a reliability signal.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,7 @@ Keep changes aligned with that ordering unless you are intentionally changing th
 | --- | --- |
 | `src/main/kotlin/io/github/aeshen/observability/` | core public API, pipeline, sinks, processors, diagnostics |
 | `query-spi/` | optional backend-agnostic audit query SPI |
+| `sidecar/` | runnable OpenAPI-described HTTP ingestion sidecar |
 | `benchmarks/` | comparative performance and backpressure harness |
 | `examples/third-party-sink-example/` | reference external sink/provider module with conformance tests |
 | `docs/` | architecture notes, extension contracts, release docs, schemas, ADRs |
@@ -34,6 +35,7 @@ Keep changes aligned with that ordering unless you are intentionally changing th
 - Treat this as a structured event framework, not a thin logging wrapper.
 - Preserve `Closeable` lifecycle semantics for `Observability` and sinks.
 - Keep optional integrations optional at runtime boundaries.
+- The sidecar's OpenAPI contract lives at `sidecar/src/main/openapi/sidecar-v1.yaml`; generated Kotlin models are build outputs.
 - Treat stable SPI surfaces carefully; see [`docs/spi-contract.md`](./docs/spi-contract.md).
 - Validate reliability-sensitive changes against `AUDIT_DURABLE`.
 
@@ -77,14 +79,14 @@ _Avoid_: Retry sink, durable buffer, primary sink
 
 ## Flagged ambiguities
 
-- `AUDIT_DURABLE` is a public profile name, but it is not **durable delivery** in the glossary sense because it does not enable persistent buffering. Treat it as an audit-oriented profile that makes delivery stricter with retry and batching while keeping the canonical meaning of **durable delivery** reserved for restart-surviving persistence.
+- `AUDIT_DURABLE` is a restart-safe **durable delivery** profile. It requires a `persistentBufferDirectory`, journals events before accepting them, and replays unacknowledged events after restart.
 - A **DLQ sink** is a fallback destination used after delegated delivery fails. It is not automatically **durable delivery**; it is only restart-safe if the configured DLQ sink itself persists events durably.
 
 ### Example dialogue
 
 > **Developer:** If I set `AUDIT_DURABLE`, do I now have durable delivery?
 >
-> **Domain expert:** No. That profile makes delivery stricter and more resilient in memory, but **durable delivery** still requires a **persistent buffer**.
+> **Domain expert:** Yes. The profile requires a **persistent buffer**, journals before acceptance, and replays unacknowledged events after restart.
 >
 > **Developer:** If the process crashes after buffering but before the sink confirms delivery, what do we call the next startup behavior?
 >

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Sinks (fan-out)      (write to Console, File, OpenTelemetry, …)
 - **Optional encryption** — AES-GCM with a fixed key, or per-event data key wrapped with RSA-OAEP-256
 - **Sensitive-field filtering** — ordered allow/mask/remove processors for `context.*`, `metadata.*`, `message`, and `payload`
 - **Reliability decorators** — `AsyncObservabilitySink`, `BatchingObservabilitySink`, `PersistentObservabilitySink`, `RetryingObservabilitySink`, `DlqObservabilitySink`
-- **Profiles** — `STANDARD` (best-effort) or `AUDIT_DURABLE` (strict, retried, batched; not crash-safe by itself)
+- **Profiles** — `STANDARD` (best-effort) or `AUDIT_DURABLE` (persistent, retried, restart-safe audit delivery)
 - **Pluggable codec** — default JSONL, fully replaceable
 - **Sink SPI** — register custom sinks via `SinkConfig` + `SinkRegistry`
 - **Global context injection** — `ContextProvider` merges ambient context into every event
@@ -727,7 +727,7 @@ Composition guidance:
 - Wrap **synchronous** sinks or synchronous decorators inside `PersistentObservabilitySink`.
 - `RetryingObservabilitySink` composes well inside the persistence boundary.
 - Do **not** wrap `BatchingObservabilitySink` or `AsyncObservabilitySink` inside `PersistentObservabilitySink`; they acknowledge before the underlying sink has actually delivered.
-- `AUDIT_DURABLE` does not enable persistent buffering. Use `PersistentObservabilitySink` explicitly when restart survival is required.
+- `AUDIT_DURABLE` requires `persistentBufferDirectory` and journals events before delivery.
 
 ### RetryingObservabilitySink
 
@@ -811,7 +811,7 @@ Best-effort delivery. `IllegalArgumentException` and `IllegalStateException` fro
 
 ### AUDIT_DURABLE
 
-Automatically wraps all sinks with retry (5 attempts, exponential backoff), batching (100-event batches, 250 ms flush), and enforces `failOnSinkError = true`. Use for audit compliance scenarios when you want a stricter in-memory delivery profile:
+Automatically wraps all sinks with a persistent journal and retry (5 attempts, exponential backoff). The journal append is the acceptance boundary: events replay in order after restart until the wrapped sink acknowledges them.
 
 ```kotlin
 val observability =
@@ -819,12 +819,13 @@ val observability =
         ObservabilityFactory.Config(
             sinks = listOf(File(Path.of("./logs/audit.jsonl"))),
             profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
+            persistentBufferDirectory = Path.of("./.observability-audit-buffer"),
             diagnostics = myDiagnostics,
         ),
     )
 ```
 
-`AUDIT_DURABLE` is a compatibility profile name, not the canonical definition of **durable delivery**. It improves in-memory reliability but is **not** crash-safe. Add `PersistentObservabilitySink` explicitly if events must survive restarts.
+`AUDIT_DURABLE` is durable delivery. It requires writable local persistent storage and provides at-least-once delivery; a successful emit means the event is journaled, not that an external sink has completed delivery.
 
 ---
 

--- a/agent.md
+++ b/agent.md
@@ -52,7 +52,7 @@ Reliability decorators:
 
 Profiles:
 - `STANDARD`
-- `AUDIT_DURABLE` (retry + batching + strict sink error propagation)
+- `AUDIT_DURABLE` (persistent journal + retry + restart replay; requires `persistentBufferDirectory`)
 
 Encryption configs:
 - `AesGcm`
@@ -78,6 +78,7 @@ From `settings.gradle.kts`:
 - `:` core observability library
 - `:query-spi` optional audit query SPI
 - `:benchmarks` sink/backpressure benchmark harness
+- `:sidecar` runnable OpenAPI-described HTTP ingestion sidecar
 - `:examples:third-party-sink-example` custom sink/provider example + conformance tests
 
 ## Working Guardrails

--- a/api/observability.api
+++ b/api/observability.api
@@ -119,11 +119,12 @@ public final class io/github/aeshen/observability/ObservabilityFactory {
 
 public final class io/github/aeshen/observability/ObservabilityFactory$Config {
 	public static final field Companion Lio/github/aeshen/observability/ObservabilityFactory$Config$Companion;
-	public fun <init> (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/nio/file/Path;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/nio/file/Path;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun aesGcmFromRawKeyBytes ([B)Lio/github/aeshen/observability/config/encryption/AesGcm;
 	public final fun component1 ()Ljava/util/List;
-	public final fun component10 ()Ljava/util/List;
+	public final fun component10 ()Ljava/nio/file/Path;
+	public final fun component11 ()Ljava/util/List;
 	public final fun component2 ()Lio/github/aeshen/observability/config/encryption/EncryptionConfig;
 	public final fun component3 ()Z
 	public final fun component4 ()Lio/github/aeshen/observability/sink/registry/SinkRegistry;
@@ -132,8 +133,8 @@ public final class io/github/aeshen/observability/ObservabilityFactory$Config {
 	public final fun component7 ()Ljava/util/List;
 	public final fun component8 ()Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;
 	public final fun component9 ()Lio/github/aeshen/observability/ObservabilityFactory$Profile;
-	public final fun copy (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/util/List;)Lio/github/aeshen/observability/ObservabilityFactory$Config;
-	public static synthetic fun copy$default (Lio/github/aeshen/observability/ObservabilityFactory$Config;Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/util/List;ILjava/lang/Object;)Lio/github/aeshen/observability/ObservabilityFactory$Config;
+	public final fun copy (Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/nio/file/Path;Ljava/util/List;)Lio/github/aeshen/observability/ObservabilityFactory$Config;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/ObservabilityFactory$Config;Ljava/util/List;Lio/github/aeshen/observability/config/encryption/EncryptionConfig;ZLio/github/aeshen/observability/sink/registry/SinkRegistry;Lio/github/aeshen/observability/codec/ObservabilityCodec;Ljava/util/List;Ljava/util/List;Lio/github/aeshen/observability/diagnostics/ObservabilityDiagnostics;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/nio/file/Path;Ljava/util/List;ILjava/lang/Object;)Lio/github/aeshen/observability/ObservabilityFactory$Config;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCodec ()Lio/github/aeshen/observability/codec/ObservabilityCodec;
 	public final fun getContextProviders ()Ljava/util/List;
@@ -141,6 +142,7 @@ public final class io/github/aeshen/observability/ObservabilityFactory$Config {
 	public final fun getEncryption ()Lio/github/aeshen/observability/config/encryption/EncryptionConfig;
 	public final fun getFailOnSinkError ()Z
 	public final fun getMetadataEnrichers ()Ljava/util/List;
+	public final fun getPersistentBufferDirectory ()Ljava/nio/file/Path;
 	public final fun getProcessors ()Ljava/util/List;
 	public final fun getProfile ()Lio/github/aeshen/observability/ObservabilityFactory$Profile;
 	public final fun getSinkRegistry ()Lio/github/aeshen/observability/sink/registry/SinkRegistry;
@@ -158,6 +160,7 @@ public final class io/github/aeshen/observability/ObservabilityFactory$Config$Bu
 	public final fun encryption (Lio/github/aeshen/observability/config/encryption/EncryptionConfig;)Lio/github/aeshen/observability/ObservabilityFactory$Config$Builder;
 	public final fun failOnSinkError (Z)Lio/github/aeshen/observability/ObservabilityFactory$Config$Builder;
 	public final fun metadataEnrichers (Ljava/util/List;)Lio/github/aeshen/observability/ObservabilityFactory$Config$Builder;
+	public final fun persistentBufferDirectory (Ljava/nio/file/Path;)Lio/github/aeshen/observability/ObservabilityFactory$Config$Builder;
 	public final fun processors (Ljava/util/List;)Lio/github/aeshen/observability/ObservabilityFactory$Config$Builder;
 	public final fun profile (Lio/github/aeshen/observability/ObservabilityFactory$Profile;)Lio/github/aeshen/observability/ObservabilityFactory$Config$Builder;
 	public final fun sinkRegistry (Lio/github/aeshen/observability/sink/registry/SinkRegistry;)Lio/github/aeshen/observability/ObservabilityFactory$Config$Builder;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 plugins {
     kotlin("jvm") version "2.3.20"
+    id("org.openapi.generator") version "7.12.0" apply false
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.18.1"

--- a/docs/adr/0003-reserve-durable-for-restart-safe-delivery-semantics.md
+++ b/docs/adr/0003-reserve-durable-for-restart-safe-delivery-semantics.md
@@ -1,3 +1,3 @@
 # ADR 0003: Reserve "durable" for restart-safe delivery semantics
 
-The library distinguishes **best-effort**, **strict**, and **durable** delivery as separate concepts. **Durable delivery** refers only to journal-backed delivery that survives process restarts and replays unacknowledged events, which today is provided by `PersistentObservabilitySink`. The existing `AUDIT_DURABLE` profile name remains for compatibility, but documentation treats it as an audit-oriented strict/retry/batch profile rather than the canonical definition of durable delivery.
+The library distinguishes **best-effort**, **strict**, and **durable** delivery as separate concepts. **Durable delivery** refers only to journal-backed delivery that survives process restarts and replays unacknowledged events. `AUDIT_DURABLE` now composes `PersistentObservabilitySink` with retrying delivery and therefore provides canonical durable delivery when configured with a persistent buffer directory.

--- a/docs/spi-contract.md
+++ b/docs/spi-contract.md
@@ -38,14 +38,15 @@ When `query-spi` evolution has recompilation or migration impact, the release no
 
 ## Audit-Hardening Profile
 
-The `AUDIT_DURABLE` profile enforces strict reliability semantics:
+The `AUDIT_DURABLE` profile enforces durable audit delivery:
 
 - Automatically wraps sinks with `RetryingObservabilitySink` (5 attempts, exponential backoff)
-- Applies `BatchingObservabilitySink` for efficient delivery (100-event batches, 250ms flush)
-- Enables `failOnSinkError = true` to surface failures
+- Wraps the retrying delegate with `PersistentObservabilitySink`
+- Requires `persistentBufferDirectory`; an event is accepted only after durable journal append
+- Replays unacknowledged events in order after restart
 - All outcomes are reported via `ObservabilityDiagnostics`
 
-`AUDIT_DURABLE` is not crash-safe persistence. If events must survive process restarts, wrap the runtime sink with `PersistentObservabilitySink` explicitly.
+Do not place asynchronous or batching decorators inside the persistent boundary because they would acknowledge before delegated delivery completes.
 
 Use when strict audit compliance is required:
 
@@ -53,6 +54,7 @@ Use when strict audit compliance is required:
 ObservabilityFactory.create(
     config.copy(
         profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
+        persistentBufferDirectory = Path.of("./.observability-audit-buffer"),
         diagnostics = myDiagnostics
     )
 )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "observability"
 include(":query-spi")
 include(":benchmarks")
 include(":examples:third-party-sink-example")
+include(":sidecar")
 
 dependencyResolutionManagement {
     repositories {

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -1,0 +1,15 @@
+FROM gradle:9.0.0-jdk21 AS build
+WORKDIR /workspace
+COPY . .
+RUN gradle :sidecar:installDist --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+RUN useradd --system --uid 10001 observability
+COPY --from=build /workspace/sidecar/build/install/sidecar /app
+RUN mkdir -p /var/lib/observability && chown -R observability:observability /app /var/lib/observability
+USER 10001
+EXPOSE 8080
+VOLUME ["/var/lib/observability"]
+ENV SIDECAR_HOST=0.0.0.0
+ENTRYPOINT ["/app/bin/sidecar"]

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -1,0 +1,34 @@
+# Observability sidecar
+
+The sidecar receives versioned HTTP event submissions and emits them through the core
+`Observability` pipeline. Its source-of-truth contract is
+[`src/main/openapi/sidecar-v1.yaml`](./src/main/openapi/sidecar-v1.yaml); Kotlin API
+models are generated during `:sidecar:compileKotlin`.
+
+## Run locally
+
+```bash
+./gradlew :sidecar:run --no-daemon
+curl -X POST http://127.0.0.1:8080/v1/events \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"request.done","level":"INFO","timestamp":"2026-07-18T12:00:00Z","context":{}}'
+```
+
+`SIDECAR_BEARER_TOKEN` enables bearer authentication. Without it, `SIDECAR_HOST` must
+resolve to a loopback address. `SIDECAR_PROFILE=AUDIT_DURABLE` requires
+`SIDECAR_PERSISTENT_BUFFER_DIRECTORY`; a successful `202` then means the event was
+written to that journal, not that an external sink has acknowledged delivery.
+
+## Container image
+
+```bash
+docker build -f sidecar/Dockerfile -t observability-sidecar:local .
+docker run --rm -p 8080:8080 \
+  -e SIDECAR_BEARER_TOKEN=change-me \
+  -e SIDECAR_PERSISTENT_BUFFER_DIRECTORY=/var/lib/observability \
+  -v observability-journal:/var/lib/observability \
+  observability-sidecar:local
+```
+
+The release workflow publishes `ghcr.io/<owner>/observability-sidecar` with the release
+tag and immutable commit-SHA tag. Mount persistent storage whenever `AUDIT_DURABLE` is used.

--- a/sidecar/api/sidecar.api
+++ b/sidecar/api/sidecar.api
@@ -1,0 +1,41 @@
+public final class io/github/aeshen/observability/sidecar/MainKt {
+	public static final fun main ()V
+	public static synthetic fun main ([Ljava/lang/String;)V
+}
+
+public final class io/github/aeshen/observability/sidecar/SidecarConfig {
+	public static final field Companion Lio/github/aeshen/observability/sidecar/SidecarConfig$Companion;
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/nio/file/Path;II)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/lang/String;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/nio/file/Path;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lio/github/aeshen/observability/ObservabilityFactory$Profile;
+	public final fun component5 ()Ljava/nio/file/Path;
+	public final fun component6 ()I
+	public final fun component7 ()I
+	public final fun copy (Ljava/lang/String;ILjava/lang/String;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/nio/file/Path;II)Lio/github/aeshen/observability/sidecar/SidecarConfig;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/sidecar/SidecarConfig;Ljava/lang/String;ILjava/lang/String;Lio/github/aeshen/observability/ObservabilityFactory$Profile;Ljava/nio/file/Path;IIILjava/lang/Object;)Lio/github/aeshen/observability/sidecar/SidecarConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBearerToken ()Ljava/lang/String;
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getMaxBatchSize ()I
+	public final fun getMaxRequestBytes ()I
+	public final fun getPersistentBufferDirectory ()Ljava/nio/file/Path;
+	public final fun getPort ()I
+	public final fun getProfile ()Lio/github/aeshen/observability/ObservabilityFactory$Profile;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/aeshen/observability/sidecar/SidecarConfig$Companion {
+	public final fun fromEnvironment (Ljava/util/Map;)Lio/github/aeshen/observability/sidecar/SidecarConfig;
+	public static synthetic fun fromEnvironment$default (Lio/github/aeshen/observability/sidecar/SidecarConfig$Companion;Ljava/util/Map;ILjava/lang/Object;)Lio/github/aeshen/observability/sidecar/SidecarConfig;
+}
+
+public final class io/github/aeshen/observability/sidecar/SidecarServer : java/lang/AutoCloseable {
+	public fun <init> (Lio/github/aeshen/observability/sidecar/SidecarConfig;Lio/github/aeshen/observability/Observability;)V
+	public fun close ()V
+	public final fun start ()V
+}
+

--- a/sidecar/build.gradle.kts
+++ b/sidecar/build.gradle.kts
@@ -1,0 +1,42 @@
+plugins {
+    kotlin("jvm") version "2.3.20"
+    kotlin("plugin.serialization") version "2.3.20"
+    application
+    id("org.openapi.generator")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":"))
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
+    testImplementation(kotlin("test"))
+}
+
+application {
+    mainClass.set("io.github.aeshen.observability.sidecar.MainKt")
+}
+
+openApiGenerate {
+    generatorName.set("kotlin")
+    inputSpec.set("$projectDir/src/main/openapi/sidecar-v1.yaml")
+    outputDir.set("$rootDir/.openapi-generated/sidecar")
+    modelPackage.set("io.github.aeshen.observability.sidecar.api.model")
+    globalProperties.set(mapOf("models" to "", "apis" to "false", "supportingFiles" to "false"))
+    configOptions.set(
+        mapOf(
+            "library" to "jvm-ktor",
+            "serializationLibrary" to "kotlinx_serialization",
+        ),
+    )
+}
+
+tasks.compileKotlin {
+    dependsOn(tasks.openApiGenerate)
+}
+
+tasks.matching { it.name == "runKtlintCheckOverMainSourceSet" }.configureEach {
+    dependsOn(tasks.openApiGenerate)
+}

--- a/sidecar/src/main/kotlin/io/github/aeshen/observability/sidecar/Main.kt
+++ b/sidecar/src/main/kotlin/io/github/aeshen/observability/sidecar/Main.kt
@@ -1,0 +1,334 @@
+package io.github.aeshen.observability.sidecar
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.github.aeshen.observability.EventName
+import io.github.aeshen.observability.Observability
+import io.github.aeshen.observability.ObservabilityContext
+import io.github.aeshen.observability.ObservabilityFactory
+import io.github.aeshen.observability.config.sink.Console
+import io.github.aeshen.observability.event
+import io.github.aeshen.observability.key.TypedKey
+import io.github.aeshen.observability.sink.EventLevel
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.Base64
+import java.util.UUID
+import java.util.concurrent.Executors
+import kotlin.time.Instant
+
+private const val JSON_CONTENT_TYPE = "application/json; charset=utf-8"
+private const val PROBLEM_CONTENT_TYPE = "application/problem+json; charset=utf-8"
+private const val DEFAULT_PORT = 8080
+private const val DEFAULT_MAX_REQUEST_BYTES = 1_048_576
+private const val DEFAULT_MAX_BATCH_SIZE = 100
+private const val HTTP_OK = 200
+private const val HTTP_ACCEPTED = 202
+private const val HTTP_BAD_REQUEST = 400
+private const val HTTP_UNAUTHORIZED = 401
+private const val HTTP_PAYLOAD_TOO_LARGE = 413
+private const val HTTP_METHOD_NOT_ALLOWED = 405
+private const val HTTP_SERVICE_UNAVAILABLE = 503
+private const val MAX_PORT = 65535
+private const val SERVER_THREADS = 4
+private const val OVER_LIMIT_READ_BYTES = 1
+
+fun main() {
+    val config = SidecarConfig.fromEnvironment()
+    val observability =
+        ObservabilityFactory.create(
+            ObservabilityFactory.Config(
+                sinks = listOf(Console),
+                profile = config.profile,
+                persistentBufferDirectory = config.persistentBufferDirectory,
+            ),
+        )
+    SidecarServer(config, observability).start()
+}
+
+data class SidecarConfig(
+    val host: String,
+    val port: Int,
+    val bearerToken: String?,
+    val profile: ObservabilityFactory.Profile,
+    val persistentBufferDirectory: Path?,
+    val maxRequestBytes: Int = DEFAULT_MAX_REQUEST_BYTES,
+    val maxBatchSize: Int = DEFAULT_MAX_BATCH_SIZE,
+) {
+    init {
+        require(port in 1..MAX_PORT) { "SIDECAR_PORT must be between 1 and $MAX_PORT." }
+        require(maxRequestBytes > 0) { "SIDECAR_MAX_REQUEST_BYTES must be greater than 0." }
+        require(maxBatchSize > 0) { "SIDECAR_MAX_BATCH_SIZE must be greater than 0." }
+        require(bearerToken != null || InetAddress.getByName(host).isLoopbackAddress) {
+            "SIDECAR_HOST must resolve to a loopback address when SIDECAR_BEARER_TOKEN is not configured."
+        }
+        require(profile != ObservabilityFactory.Profile.AUDIT_DURABLE || persistentBufferDirectory != null) {
+            "SIDECAR_PERSISTENT_BUFFER_DIRECTORY is required for AUDIT_DURABLE."
+        }
+    }
+
+    companion object {
+        fun fromEnvironment(environment: Map<String, String> = System.getenv()): SidecarConfig =
+            SidecarConfig(
+                host = environment["SIDECAR_HOST"] ?: "127.0.0.1",
+                port = environment["SIDECAR_PORT"]?.toIntOrNull() ?: DEFAULT_PORT,
+                bearerToken = environment["SIDECAR_BEARER_TOKEN"]?.takeIf(String::isNotBlank),
+                profile =
+                    environment["SIDECAR_PROFILE"]
+                        ?.let(ObservabilityFactory.Profile::valueOf)
+                        ?: ObservabilityFactory.Profile.STANDARD,
+                persistentBufferDirectory = environment["SIDECAR_PERSISTENT_BUFFER_DIRECTORY"]?.let(Path::of),
+                maxRequestBytes = environment["SIDECAR_MAX_REQUEST_BYTES"]?.toIntOrNull() ?: DEFAULT_MAX_REQUEST_BYTES,
+                maxBatchSize = environment["SIDECAR_MAX_BATCH_SIZE"]?.toIntOrNull() ?: DEFAULT_MAX_BATCH_SIZE,
+            )
+    }
+}
+
+class SidecarServer(
+    private val config: SidecarConfig,
+    private val observability: Observability,
+) : AutoCloseable {
+    private val server = HttpServer.create(InetSocketAddress(config.host, config.port), 0)
+
+    init {
+        server.executor = Executors.newFixedThreadPool(SERVER_THREADS)
+        server.createContext(
+            "/healthz",
+        ) { exchange -> exchange.respond(HTTP_OK, """{"status":"ok"}""", JSON_CONTENT_TYPE) }
+        server.createContext("/v1/events") { exchange -> handleSingle(exchange) }
+        server.createContext("/v1/events:batch") { exchange -> handleBatch(exchange) }
+    }
+
+    fun start() {
+        Runtime.getRuntime().addShutdownHook(Thread(::close, "observability-sidecar-shutdown"))
+        server.start()
+    }
+
+    override fun close() {
+        server.stop(0)
+        observability.close()
+    }
+
+    private fun handleSingle(exchange: HttpExchange) {
+        exchange.use {
+            if (!authorize(it)) return
+            if (it.requestMethod != "POST") {
+                it.problem(HTTP_METHOD_NOT_ALLOWED, "method-not-allowed", "Only POST is supported.")
+                return
+            }
+            submit(it) { body -> listOf(parseEvent(body.jsonObject)) }
+        }
+    }
+
+    private fun handleBatch(exchange: HttpExchange) {
+        exchange.use {
+            if (!authorize(it)) return
+            if (it.requestMethod != "POST") {
+                it.problem(HTTP_METHOD_NOT_ALLOWED, "method-not-allowed", "Only POST is supported.")
+                return
+            }
+            submit(it) { body ->
+                val objectBody = body.jsonObject.requireOnly("events")
+                val events = objectBody["events"]?.jsonArray ?: throw RequestValidationException("events is required.")
+                require(events.isNotEmpty()) { "events must not be empty." }
+                require(events.size <= config.maxBatchSize) { "events exceeds the configured batch limit." }
+                events.map { parseEvent(it.jsonObject) }
+            }
+        }
+    }
+
+    private fun submit(
+        exchange: HttpExchange,
+        parse: (JsonElement) -> List<io.github.aeshen.observability.ObservabilityEvent>,
+    ) {
+        try {
+            val body =
+                exchange.requestBody.use { input ->
+                    input.readNBytes(config.maxRequestBytes + OVER_LIMIT_READ_BYTES).also {
+                        if (it.size > config.maxRequestBytes) {
+                            throw RequestTooLargeException()
+                        }
+                    }
+                }
+            val events = parse(Json.parseToJsonElement(body.decodeToString()))
+            events.forEach(observability::emit)
+            exchange.respond(
+                HTTP_ACCEPTED,
+                buildJsonObject {
+                    put("submissionId", UUID.randomUUID().toString())
+                    put("acceptedCount", events.size)
+                }.toString(),
+                JSON_CONTENT_TYPE,
+            )
+        } catch (_: RequestTooLargeException) {
+            exchange.problem(
+                HTTP_PAYLOAD_TOO_LARGE,
+                "payload-too-large",
+                "The request exceeds the configured size limit.",
+            )
+        } catch (e: RequestValidationException) {
+            exchange.problem(HTTP_BAD_REQUEST, "invalid-request", e.message ?: "The request is invalid.")
+        } catch (e: IllegalArgumentException) {
+            exchange.problem(HTTP_BAD_REQUEST, "invalid-request", e.message ?: "The request is invalid.")
+        } catch (e: IllegalStateException) {
+            exchange.problem(HTTP_SERVICE_UNAVAILABLE, "unavailable", e.message ?: "The sidecar cannot accept events.")
+        }
+    }
+
+    private fun authorize(exchange: HttpExchange): Boolean {
+        val expected = config.bearerToken ?: return true
+        val supplied = exchange.requestHeaders.getFirst("Authorization")?.removePrefix("Bearer ") ?: ""
+        if (!MessageDigest.isEqual(expected.encodeToByteArray(), supplied.encodeToByteArray())) {
+            exchange.problem(HTTP_UNAUTHORIZED, "unauthorized", "A valid bearer token is required.")
+            return false
+        }
+        return true
+    }
+
+    private fun parseEvent(input: JsonObject): io.github.aeshen.observability.ObservabilityEvent {
+        input.requireOnly("name", "level", "timestamp", "message", "context", "payloadBase64", "error")
+        val name = input.requiredString("name")
+        val level = parseLevel(input.requiredString("level"))
+        val timestamp = parseTimestamp(input.requiredString("timestamp"))
+        val context = input["context"]?.jsonObject ?: throw RequestValidationException("context is required.")
+        val payload = input["payloadBase64"]?.jsonPrimitive?.contentOrNull?.let(::decodePayload)
+        val remoteError = input["error"]?.jsonObject?.toRemoteError()
+        return event(SubmittedEventName(name)) {
+            level(level)
+            timestamp(timestamp)
+            context(context.toObservabilityContext())
+            input["message"]?.jsonPrimitive?.contentOrNull?.let(::message)
+            payload?.let(::payload)
+            remoteError?.let(::error)
+        }
+    }
+
+    private fun parseLevel(value: String): EventLevel =
+        try {
+            EventLevel.valueOf(value)
+        } catch (_: IllegalArgumentException) {
+            throw RequestValidationException("level must be a supported event level.")
+        }
+
+    private fun parseTimestamp(value: String): Instant =
+        try {
+            Instant.parse(value)
+        } catch (_: IllegalArgumentException) {
+            throw RequestValidationException("timestamp must be an ISO-8601 instant.")
+        }
+
+    private fun decodePayload(value: String): ByteArray =
+        try {
+            Base64.getDecoder().decode(value)
+        } catch (_: IllegalArgumentException) {
+            throw RequestValidationException("payloadBase64 must be valid Base64.")
+        }
+}
+
+private class SubmittedEventName(
+    private val value: String,
+) : EventName {
+    override val name: String = value
+    override val eventName: String? = value
+}
+
+private class RemoteEventException(
+    type: String,
+    message: String?,
+    val remoteStacktrace: String,
+) : RuntimeException("$type${message?.let { ": $it" } ?: ""}")
+
+private class DynamicContextKey(
+    override val keyName: String,
+) : TypedKey<Any>
+
+private class RequestValidationException(
+    override val message: String,
+) : IllegalArgumentException(message)
+
+private class RequestTooLargeException : RuntimeException()
+
+private fun JsonObject.toObservabilityContext(): ObservabilityContext {
+    val builder = ObservabilityContext.builder()
+    forEach { (key, value) ->
+        val primitive =
+            value as? JsonPrimitive ?: throw RequestValidationException(
+                "context.$key must be a scalar value.",
+            )
+        val scalar: Any =
+            when {
+                primitive.isString -> primitive.content
+                primitive.booleanOrNull != null -> primitive.boolean
+                primitive.longOrNull != null -> primitive.long
+                primitive.doubleOrNull != null -> primitive.double
+                else -> throw RequestValidationException("context.$key must be a scalar value.")
+            }
+        builder.put(DynamicContextKey(key), scalar)
+    }
+    return builder.build()
+}
+
+private fun JsonObject.toRemoteError(): Throwable {
+    requireOnly("type", "message", "stacktrace")
+    val type = requiredString("type")
+    val stacktrace = requiredString("stacktrace")
+    return RemoteEventException(type, this["message"]?.jsonPrimitive?.contentOrNull, stacktrace)
+}
+
+private fun JsonObject.requiredString(name: String): String =
+    this[name]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank)
+        ?: throw RequestValidationException("$name is required.")
+
+private fun JsonObject.requireOnly(vararg names: String): JsonObject {
+    val allowed = names.toSet()
+    val unknown = keys - allowed
+    if (unknown.isNotEmpty()) {
+        throw RequestValidationException("Unknown properties: ${unknown.sorted().joinToString()}.")
+    }
+    return this
+}
+
+private fun HttpExchange.problem(
+    status: Int,
+    type: String,
+    detail: String,
+) {
+    respond(
+        status,
+        buildJsonObject {
+            put("type", "https://github.com/janhaesen/observability/problems/$type")
+            put("title", type.replace('-', ' '))
+            put("status", status)
+            put("detail", detail)
+        }.toString(),
+        PROBLEM_CONTENT_TYPE,
+    )
+}
+
+private fun HttpExchange.respond(
+    status: Int,
+    body: String,
+    contentType: String,
+) {
+    responseHeaders.set("Content-Type", contentType)
+    sendResponseHeaders(status, body.encodeToByteArray().size.toLong())
+    responseBody.use { it.write(body.encodeToByteArray()) }
+}

--- a/sidecar/src/main/openapi/sidecar-v1.yaml
+++ b/sidecar/src/main/openapi/sidecar-v1.yaml
@@ -1,0 +1,152 @@
+openapi: 3.0.3
+info:
+  title: Observability Sidecar API
+  version: 1.0.0
+  description: Versioned ingress API for submitting structured observability events to a local sidecar.
+servers:
+  - url: http://127.0.0.1:8080
+security:
+  - bearerAuth: []
+paths:
+  /v1/events:
+    post:
+      operationId: submitEvent
+      summary: Submit one event
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventSubmission'
+      responses:
+        '202':
+          description: Event accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmissionReceipt'
+        '400':
+          $ref: '#/components/responses/Problem'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '413':
+          $ref: '#/components/responses/Problem'
+        '503':
+          $ref: '#/components/responses/Problem'
+  /v1/events:batch:
+    post:
+      operationId: submitEvents
+      summary: Submit an atomic batch of events
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventBatchSubmission'
+      responses:
+        '202':
+          description: All events accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmissionReceipt'
+        '400':
+          $ref: '#/components/responses/Problem'
+        '401':
+          $ref: '#/components/responses/Problem'
+        '413':
+          $ref: '#/components/responses/Problem'
+        '503':
+          $ref: '#/components/responses/Problem'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque
+  responses:
+    Problem:
+      description: Request could not be processed.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+  schemas:
+    EventSubmission:
+      type: object
+      additionalProperties: false
+      required: [name, level, timestamp, context]
+      properties:
+        name:
+          type: string
+          minLength: 1
+        level:
+          type: string
+          enum: [TRACE, DEBUG, INFO, WARN, ERROR]
+        timestamp:
+          type: string
+          format: date-time
+        message:
+          type: string
+          nullable: true
+        context:
+          type: object
+          additionalProperties:
+            nullable: true
+            oneOf:
+              - type: string
+              - type: number
+              - type: boolean
+        payloadBase64:
+          type: string
+          format: byte
+        error:
+          $ref: '#/components/schemas/RemoteError'
+    EventBatchSubmission:
+      type: object
+      additionalProperties: false
+      required: [events]
+      properties:
+        events:
+          type: array
+          minItems: 1
+          maxItems: 100
+          items:
+            $ref: '#/components/schemas/EventSubmission'
+    RemoteError:
+      type: object
+      additionalProperties: false
+      required: [type, stacktrace]
+      properties:
+        type:
+          type: string
+          minLength: 1
+        message:
+          type: string
+          nullable: true
+        stacktrace:
+          type: string
+          minLength: 1
+    SubmissionReceipt:
+      type: object
+      required: [submissionId, acceptedCount]
+      properties:
+        submissionId:
+          type: string
+          format: uuid
+        acceptedCount:
+          type: integer
+          minimum: 1
+    Problem:
+      type: object
+      required: [type, title, status]
+      properties:
+        type:
+          type: string
+          format: uri-reference
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string

--- a/sidecar/src/test/kotlin/io/github/aeshen/observability/sidecar/SidecarConfigTest.kt
+++ b/sidecar/src/test/kotlin/io/github/aeshen/observability/sidecar/SidecarConfigTest.kt
@@ -1,0 +1,35 @@
+package io.github.aeshen.observability.sidecar
+
+import io.github.aeshen.observability.ObservabilityFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class SidecarConfigTest {
+    @Test
+    fun `unauthenticated sidecar accepts loopback binding`() {
+        val config = SidecarConfig.fromEnvironment(mapOf("SIDECAR_HOST" to "127.0.0.1"))
+
+        assertEquals("127.0.0.1", config.host)
+        assertNull(config.bearerToken)
+    }
+
+    @Test
+    fun `unauthenticated sidecar rejects public binding`() {
+        assertFailsWith<IllegalArgumentException> {
+            SidecarConfig.fromEnvironment(mapOf("SIDECAR_HOST" to "0.0.0.0"))
+        }
+    }
+
+    @Test
+    fun `audit durable requires persistent storage`() {
+        assertFailsWith<IllegalArgumentException> {
+            SidecarConfig.fromEnvironment(
+                mapOf(
+                    "SIDECAR_PROFILE" to ObservabilityFactory.Profile.AUDIT_DURABLE.name,
+                ),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/io/github/aeshen/observability/ObservabilityFactory.kt
+++ b/src/main/kotlin/io/github/aeshen/observability/ObservabilityFactory.kt
@@ -11,10 +11,11 @@ import io.github.aeshen.observability.enricher.MetadataEnricher
 import io.github.aeshen.observability.processor.ObservabilityProcessor
 import io.github.aeshen.observability.processor.encryption.EncryptingObservabilityProcessor
 import io.github.aeshen.observability.sink.ObservabilitySink
-import io.github.aeshen.observability.sink.decorator.BatchingObservabilitySink
+import io.github.aeshen.observability.sink.decorator.PersistentObservabilitySink
 import io.github.aeshen.observability.sink.decorator.RetryingObservabilitySink
 import io.github.aeshen.observability.sink.registry.SinkRegistry
 import io.github.aeshen.observability.util.CryptoUtils
+import java.nio.file.Path
 import javax.crypto.spec.SecretKeySpec
 
 object ObservabilityFactory {
@@ -22,8 +23,6 @@ object ObservabilityFactory {
     private const val BYTE_24 = 24
     private const val BYTE_32 = 32
     private const val AUDIT_MAX_ATTEMPTS = 5
-    private const val AUDIT_MAX_BATCH_SIZE = 100
-    private const val AUDIT_FLUSH_INTERVAL_MILLIS = 250L
 
     enum class Profile {
         STANDARD,
@@ -40,6 +39,7 @@ object ObservabilityFactory {
         val metadataEnrichers: List<MetadataEnricher> = emptyList(),
         val diagnostics: ObservabilityDiagnostics = ObservabilityDiagnostics.NOOP,
         val profile: Profile = Profile.STANDARD,
+        val persistentBufferDirectory: Path? = null,
         val processors: List<ObservabilityProcessor> = emptyList(),
     ) {
         companion object {
@@ -76,6 +76,7 @@ object ObservabilityFactory {
             private var metadataEnrichers: List<MetadataEnricher> = emptyList()
             private var diagnostics: ObservabilityDiagnostics = ObservabilityDiagnostics.NOOP
             private var profile: Profile = Profile.STANDARD
+            private var persistentBufferDirectory: Path? = null
             private var processors: List<ObservabilityProcessor> = emptyList()
 
             fun encryption(value: EncryptionConfig?) = apply { encryption = value }
@@ -94,6 +95,8 @@ object ObservabilityFactory {
 
             fun profile(value: Profile) = apply { profile = value }
 
+            fun persistentBufferDirectory(value: Path?) = apply { persistentBufferDirectory = value }
+
             fun processors(value: List<ObservabilityProcessor>) = apply { processors = value }
 
             fun build(): Config =
@@ -107,6 +110,7 @@ object ObservabilityFactory {
                     metadataEnrichers = metadataEnrichers,
                     diagnostics = diagnostics,
                     profile = profile,
+                    persistentBufferDirectory = persistentBufferDirectory,
                     processors = processors,
                 )
         }
@@ -119,6 +123,7 @@ object ObservabilityFactory {
                 buildSinks(config),
                 config.profile,
                 config.diagnostics,
+                config.persistentBufferDirectory,
             )
 
         require(sinks.isNotEmpty()) { "At least one sink must be configured." }
@@ -179,6 +184,7 @@ object ObservabilityFactory {
         sinks: List<ObservabilitySink>,
         profile: Profile,
         diagnostics: ObservabilityDiagnostics,
+        persistentBufferDirectory: Path?,
     ): List<ObservabilitySink> =
         when (profile) {
             Profile.STANDARD -> {
@@ -186,17 +192,19 @@ object ObservabilityFactory {
             }
 
             Profile.AUDIT_DURABLE -> {
-                sinks.map { sink ->
-                    BatchingObservabilitySink(
+                val directory =
+                    requireNotNull(persistentBufferDirectory) {
+                        "AUDIT_DURABLE requires persistentBufferDirectory."
+                    }
+                sinks.mapIndexed { index, sink ->
+                    PersistentObservabilitySink(
                         delegate =
                             RetryingObservabilitySink(
                                 delegate = sink,
                                 maxAttempts = AUDIT_MAX_ATTEMPTS,
                                 diagnostics = diagnostics,
                             ),
-                        maxBatchSize = AUDIT_MAX_BATCH_SIZE,
-                        flushIntervalMillis = AUDIT_FLUSH_INTERVAL_MILLIS,
-                        diagnostics = diagnostics,
+                        directory = directory.resolve("sink-$index"),
                     )
                 }
             }

--- a/src/test/kotlin/io/github/aeshen/observability/ObservabilityFactoryTest.kt
+++ b/src/test/kotlin/io/github/aeshen/observability/ObservabilityFactoryTest.kt
@@ -11,6 +11,7 @@ import io.github.aeshen.observability.processor.builtin.SensitiveFieldRule
 import io.github.aeshen.observability.sink.ObservabilitySink
 import io.github.aeshen.observability.sink.registry.SinkRegistry
 import java.net.InetSocketAddress
+import java.nio.file.Files
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -300,30 +301,19 @@ class ObservabilityFactoryTest {
     }
 
     @Test
-    fun `audit durable profile enforces strict sink failures`() {
-        val failing =
-            object : ObservabilitySink {
-                override fun handle(event: EncodedEvent) = error("always fails")
-            }
-        val registry = directSinkRegistry()
-
-        val observability =
+    fun `audit durable profile requires a persistent buffer directory`() {
+        assertFailsWith<IllegalArgumentException> {
             ObservabilityFactory.create(
                 ObservabilityFactory.Config(
-                    sinks = listOf(DirectSinkConfig(failing)),
-                    sinkRegistry = registry,
-                    failOnSinkError = false,
+                    sinks = listOf(ThirdPartySinkConfig("audit-profile")),
+                    sinkRegistry =
+                        SinkRegistry
+                            .builder()
+                            .register<ThirdPartySinkConfig> { CapturingSink(mutableListOf()) }
+                            .build(),
                     profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
                 ),
             )
-
-        assertFailsWith<IllegalStateException> {
-            observability.use {
-                it.info(
-                    name = TestEvent.TEST,
-                    message = "must fail",
-                )
-            }
         }
     }
 
@@ -346,6 +336,7 @@ class ObservabilityFactoryTest {
                     sinks = listOf(DirectSinkConfig(flaky)),
                     sinkRegistry = registry,
                     profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
+                    persistentBufferDirectory = Files.createTempDirectory("audit-profile-retry"),
                 ),
             )
 
@@ -357,102 +348,6 @@ class ObservabilityFactoryTest {
         }
 
         assertEquals(3, attempts.get())
-    }
-
-    @Test
-    fun `diagnostics are wired through factory config`() {
-        val diagnosticEvents = mutableListOf<String>()
-        val diagnostics =
-            object : io.github.aeshen.observability.diagnostics.ObservabilityDiagnostics {
-                override fun onBatchFlush(
-                    batchSize: Int,
-                    elapsedMillis: Long,
-                    success: Boolean,
-                    error: Exception?,
-                ) {
-                    diagnosticEvents += "flush:$batchSize:$success"
-                }
-
-                override fun onRetryExhaustion(
-                    event: EncodedEvent,
-                    attempts: Int,
-                    lastError: Exception,
-                ) {
-                    diagnosticEvents += "retry_fail:$attempts"
-                }
-            }
-
-        val observability =
-            ObservabilityFactory.create(
-                ObservabilityFactory.Config(
-                    sinks = listOf(ThirdPartySinkConfig("test")),
-                    sinkRegistry =
-                        SinkRegistry
-                            .builder()
-                            .register<ThirdPartySinkConfig> {
-                                CapturingSink(mutableListOf())
-                            }.build(),
-                    profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
-                    diagnostics = diagnostics,
-                ),
-            )
-
-        observability.use {
-            it.info(
-                name = TestEvent.TEST,
-                message = "with diagnostics",
-            )
-        }
-
-        assertTrue(
-            diagnosticEvents.any { it.startsWith("flush") },
-            "Batch flush should be reported by diagnostics",
-        )
-    }
-
-    @Test
-    fun `audit profile with diagnostics tracks retry exhaustion`() {
-        val diagnosticEvents = mutableListOf<String>()
-        val diagnostics =
-            object : io.github.aeshen.observability.diagnostics.ObservabilityDiagnostics {
-                override fun onRetryExhaustion(
-                    event: EncodedEvent,
-                    attempts: Int,
-                    lastError: Exception,
-                ) {
-                    diagnosticEvents += "exhausted:$attempts"
-                }
-            }
-
-        val failing =
-            object : ObservabilitySink {
-                override fun handle(event: EncodedEvent) = error("always fail")
-            }
-        val registry = directSinkRegistry()
-
-        val observability =
-            ObservabilityFactory.create(
-                ObservabilityFactory.Config(
-                    sinks = listOf(DirectSinkConfig(failing)),
-                    sinkRegistry = registry,
-                    profile = ObservabilityFactory.Profile.AUDIT_DURABLE,
-                    diagnostics = diagnostics,
-                ),
-            )
-
-        assertFailsWith<IllegalStateException> {
-            observability.use {
-                it.info(
-                    name = TestEvent.TEST,
-                    message = "will exhaust retries",
-                )
-            }
-        }
-
-        assertTrue(
-            diagnosticEvents.any { it.contains("exhausted") },
-            "Retry exhaustion should be reported",
-        )
     }
 
     private class CapturedRequest(


### PR DESCRIPTION
- add versioned OpenAPI contract and generated Kotlin API models
- implement single and atomic batch event submission endpoints
- enforce bearer authentication or loopback-only unauthenticated binding
- add Docker image build and GHCR release publishing
- make AUDIT_DURABLE persist events before acknowledgement and replay after restart
- document sidecar deployment, durability, and migration requirements

Closes #50

## What changed

<!-- Briefly describe the change and why -->

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs only
- [x] Build/CI
- [ ] Release prep

## Scope touched

- [x] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [x] Built-in sinks / decorators / providers
- [ ] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [x] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`)
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [x] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [x] Added/updated tests
- [x] Ran `./gradlew test`
- [ ] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew ktlintCheck`
- [x] Ran `./gradlew detekt`
- [x] Security scan status checked when the change affects dependencies or release surfaces
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [ ] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [x] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [x] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [ ] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [x] Updated `CHANGELOG.md` (if needed)
- [ ] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [x] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
