### PR TITLE
feat: add durable sidecar SDKs for JVM and Go

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -12,6 +12,8 @@
             <option value="$PROJECT_DIR$/examples" />
             <option value="$PROJECT_DIR$/examples/third-party-sink-example" />
             <option value="$PROJECT_DIR$/query-spi" />
+            <option value="$PROJECT_DIR$/sidecar" />
+            <option value="$PROJECT_DIR$/sidecar-client-jvm" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -69,6 +69,10 @@ _Avoid_: Recovery resend, best-effort resend
 A journaled event whose delegated delivery completed, allowing the persistent buffer to advance retention and cleanup.
 _Avoid_: Flushed event, processed event
 
+**Client event ID**:
+A stable UUID assigned before API submission and preserved through sidecar processing so downstream consumers can deduplicate at-least-once delivery.
+_Avoid_: Envelope ID, transport ID, request ID
+
 **Dead-letter routing**:
 Delivery behavior where a decorator writes an event to a designated **DLQ sink** after delegated delivery fails with an eligible exception.
 _Avoid_: Failure routing, fallback mirroring, durable delivery

--- a/client-go/client.go
+++ b/client-go/client.go
@@ -1,0 +1,419 @@
+package sidecarclient
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBaseURL            = "http://127.0.0.1:8080"
+	defaultUserAgent          = "observability-client-go"
+	singleSubmissionPath      = "/v1/events"
+	batchSubmissionPath       = "/v1/events:batch"
+	maxContractBatchSize      = 100
+	maxErrorResponseBodyBytes = 1 << 20
+)
+
+// Config configures direct sidecar submission.
+type Config struct {
+	BaseURL       string
+	HTTPClient    *http.Client
+	TokenProvider TokenProvider
+	UserAgent     string
+}
+
+// Client submits events directly to the sidecar HTTP API.
+type Client struct {
+	baseURL       *url.URL
+	httpClient    *http.Client
+	tokenProvider TokenProvider
+	userAgent     string
+}
+
+// NewClient builds a direct HTTP sidecar client.
+func NewClient(cfg Config) (*Client, error) {
+	baseURL := cfg.BaseURL
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = defaultBaseURL
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse base url: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("base url must include scheme and host")
+	}
+	userAgent := cfg.UserAgent
+	if strings.TrimSpace(userAgent) == "" {
+		userAgent = defaultUserAgent
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{
+		baseURL:       parsed,
+		httpClient:    httpClient,
+		tokenProvider: cfg.TokenProvider,
+		userAgent:     userAgent,
+	}, nil
+}
+
+// Submit sends one event to POST /v1/events.
+func (c *Client) Submit(ctx context.Context, event Event) (SubmissionResult, error) {
+	normalized, preparedWireEvent, err := prepareEvent(event)
+	if err != nil {
+		return SubmissionResult{}, err
+	}
+	receipt, err := c.submitPrepared(ctx, []wireEvent{preparedWireEvent})
+	if err != nil {
+		return SubmissionResult{}, err
+	}
+	return SubmissionResult{Receipt: receipt, Events: []Event{normalized}}, nil
+}
+
+// SubmitBatch sends up to 100 events to POST /v1/events:batch.
+func (c *Client) SubmitBatch(ctx context.Context, events []Event) (SubmissionResult, error) {
+	normalized, wireEvents, err := prepareEvents(events)
+	if err != nil {
+		return SubmissionResult{}, err
+	}
+	receipt, err := c.submitPrepared(ctx, wireEvents)
+	if err != nil {
+		return SubmissionResult{}, err
+	}
+	return SubmissionResult{Receipt: receipt, Events: normalized}, nil
+}
+
+func (c *Client) submitPrepared(ctx context.Context, wireEvents []wireEvent) (SubmissionReceipt, error) {
+	var path string
+	var payload any
+	if len(wireEvents) == 1 {
+		path = singleSubmissionPath
+		payload = wireEvents[0]
+	} else {
+		path = batchSubmissionPath
+		payload = wireBatch{Events: wireEvents}
+	}
+	return c.doSubmit(ctx, path, payload, len(wireEvents))
+}
+
+func (c *Client) doSubmit(ctx context.Context, path string, payload any, expectedAccepted int) (SubmissionReceipt, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return SubmissionReceipt{}, fmt.Errorf("marshal request: %w", err)
+	}
+	endpoint := c.baseURL.ResolveReference(&url.URL{Path: path})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return SubmissionReceipt{}, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, application/problem+json")
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+	if c.tokenProvider != nil {
+		token, err := c.tokenProvider.Token(ctx)
+		if err != nil {
+			return SubmissionReceipt{}, fmt.Errorf("resolve bearer token: %w", err)
+		}
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return SubmissionReceipt{}, err
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorResponseBodyBytes))
+	if err != nil {
+		return SubmissionReceipt{}, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		return SubmissionReceipt{}, parseHTTPError(resp.StatusCode, responseBody)
+	}
+	var receipt SubmissionReceipt
+	if err := json.Unmarshal(responseBody, &receipt); err != nil {
+		return SubmissionReceipt{}, fmt.Errorf("decode receipt: %w", err)
+	}
+	if !isUUID(receipt.SubmissionID) {
+		return SubmissionReceipt{}, fmt.Errorf("decode receipt: submissionId must be a UUID")
+	}
+	if receipt.AcceptedCount != expectedAccepted {
+		return SubmissionReceipt{}, fmt.Errorf(
+			"decode receipt: acceptedCount=%d, want %d",
+			receipt.AcceptedCount,
+			expectedAccepted,
+		)
+	}
+	return receipt, nil
+}
+
+func parseHTTPError(statusCode int, body []byte) error {
+	httpErr := &HTTPError{StatusCode: statusCode, Body: strings.TrimSpace(string(body))}
+	var problem Problem
+	if len(body) > 0 && json.Unmarshal(body, &problem) == nil && problem.Title != "" {
+		httpErr.Problem = &problem
+	}
+	return httpErr
+}
+
+func prepareEvents(events []Event) ([]Event, []wireEvent, error) {
+	if len(events) == 0 {
+		return nil, nil, fmt.Errorf("at least one event is required")
+	}
+	if len(events) > maxContractBatchSize {
+		return nil, nil, fmt.Errorf("batch size %d exceeds contract limit %d", len(events), maxContractBatchSize)
+	}
+	normalized := make([]Event, len(events))
+	wireEvents := make([]wireEvent, len(events))
+	for i, event := range events {
+		prepared, wire, err := prepareEvent(event)
+		if err != nil {
+			return nil, nil, fmt.Errorf("event %d: %w", i, err)
+		}
+		normalized[i] = prepared
+		wireEvents[i] = wire
+	}
+	return normalized, wireEvents, nil
+}
+
+func prepareEvent(event Event) (Event, wireEvent, error) {
+	id, err := normalizeClientEventID(event.ClientEventID)
+	if err != nil {
+		return Event{}, wireEvent{}, err
+	}
+	if strings.TrimSpace(event.Name) == "" {
+		return Event{}, wireEvent{}, fmt.Errorf("name is required")
+	}
+	if !event.Level.valid() {
+		return Event{}, wireEvent{}, fmt.Errorf("level must be one of TRACE, DEBUG, INFO, WARN, ERROR")
+	}
+	if event.Timestamp.IsZero() {
+		return Event{}, wireEvent{}, fmt.Errorf("timestamp is required")
+	}
+	contextMap, err := normalizeContext(event.Context)
+	if err != nil {
+		return Event{}, wireEvent{}, err
+	}
+	prepared := Event{
+		ClientEventID: id,
+		Name:          event.Name,
+		Level:         event.Level,
+		Timestamp:     event.Timestamp.UTC(),
+		Message:       cloneString(event.Message),
+		Context:       contextMap,
+		Payload:       bytes.Clone(event.Payload),
+	}
+	wire := wireEvent{
+		ClientEventID: id,
+		Name:          event.Name,
+		Level:         string(event.Level),
+		Timestamp:     event.Timestamp.UTC().Format(time.RFC3339Nano),
+		Message:       cloneString(event.Message),
+		Context:       contextMap,
+	}
+	if len(event.Payload) > 0 {
+		wire.PayloadBase64 = event.Payload
+	}
+	if event.Error != nil {
+		remoteError, err := normalizeRemoteError(event.Error)
+		if err != nil {
+			return Event{}, wireEvent{}, err
+		}
+		prepared.Error = remoteError.toPublic()
+		wire.Error = remoteError
+	}
+	return prepared, wire, nil
+}
+
+func normalizeRemoteError(remoteError *RemoteError) (*wireRemoteError, error) {
+	if remoteError == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(remoteError.Type) == "" {
+		return nil, fmt.Errorf("error.type is required")
+	}
+	if strings.TrimSpace(remoteError.Stacktrace) == "" {
+		return nil, fmt.Errorf("error.stacktrace is required")
+	}
+	return &wireRemoteError{
+		Type:       remoteError.Type,
+		Message:    cloneString(remoteError.Message),
+		Stacktrace: remoteError.Stacktrace,
+	}, nil
+}
+
+func normalizeContext(contextMap map[string]any) (map[string]any, error) {
+	if contextMap == nil {
+		return map[string]any{}, nil
+	}
+	normalized := make(map[string]any, len(contextMap))
+	for key, value := range contextMap {
+		normalizedValue, ok := normalizeContextValue(value)
+		if !ok {
+			return nil, fmt.Errorf("context.%s must be a string, bool, or finite number", key)
+		}
+		normalized[key] = normalizedValue
+	}
+	return normalized, nil
+}
+
+func normalizeContextValue(value any) (any, bool) {
+	switch typed := value.(type) {
+	case string:
+		return typed, true
+	case bool:
+		return typed, true
+	case int:
+		return typed, true
+	case int8:
+		return typed, true
+	case int16:
+		return typed, true
+	case int32:
+		return typed, true
+	case int64:
+		return typed, true
+	case uint:
+		return typed, true
+	case uint8:
+		return typed, true
+	case uint16:
+		return typed, true
+	case uint32:
+		return typed, true
+	case uint64:
+		return typed, true
+	case float32:
+		return normalizeFloat(float64(typed))
+	case float64:
+		return normalizeFloat(typed)
+	case json.Number:
+		if floatValue, err := typed.Float64(); err == nil {
+			return normalizeFloat(floatValue)
+		}
+		return nil, false
+	default:
+		return nil, false
+	}
+}
+
+func normalizeFloat(value float64) (any, bool) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return nil, false
+	}
+	return value, true
+}
+
+func normalizeClientEventID(id string) (string, error) {
+	if strings.TrimSpace(id) == "" {
+		return newUUID()
+	}
+	if !isUUID(id) {
+		return "", fmt.Errorf("clientEventId must be a UUID")
+	}
+	return strings.ToLower(id), nil
+}
+
+func newUUID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate clientEventId: %w", err)
+	}
+	raw[6] = (raw[6] & 0x0f) | 0x40
+	raw[8] = (raw[8] & 0x3f) | 0x80
+	return fmt.Sprintf(
+		"%08x-%04x-%04x-%04x-%012x",
+		raw[0:4],
+		raw[4:6],
+		raw[6:8],
+		raw[8:10],
+		raw[10:16],
+	), nil
+}
+
+func isUUID(value string) bool {
+	if len(value) != 36 {
+		return false
+	}
+	for i, r := range value {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			if !isHex(r) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isHex(r rune) bool {
+	return ('0' <= r && r <= '9') || ('a' <= r && r <= 'f') || ('A' <= r && r <= 'F')
+}
+
+func cloneString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func (l Level) valid() bool {
+	switch l {
+	case LevelTrace, LevelDebug, LevelInfo, LevelWarn, LevelError:
+		return true
+	default:
+		return false
+	}
+}
+
+type wireEvent struct {
+	ClientEventID string           `json:"clientEventId"`
+	Name          string           `json:"name"`
+	Level         string           `json:"level"`
+	Timestamp     string           `json:"timestamp"`
+	Message       *string          `json:"message,omitempty"`
+	Context       map[string]any   `json:"context"`
+	PayloadBase64 []byte           `json:"payloadBase64,omitempty"`
+	Error         *wireRemoteError `json:"error,omitempty"`
+}
+
+type wireBatch struct {
+	Events []wireEvent `json:"events"`
+}
+
+type wireRemoteError struct {
+	Type       string  `json:"type"`
+	Message    *string `json:"message,omitempty"`
+	Stacktrace string  `json:"stacktrace"`
+}
+
+func (w *wireRemoteError) toPublic() *RemoteError {
+	if w == nil {
+		return nil
+	}
+	return &RemoteError{
+		Type:       w.Type,
+		Message:    cloneString(w.Message),
+		Stacktrace: w.Stacktrace,
+	}
+}

--- a/client-go/client_test.go
+++ b/client-go/client_test.go
@@ -1,0 +1,156 @@
+package sidecarclient
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestClientSubmitGeneratesClientEventIDAndUsesTokenProvider(t *testing.T) {
+	t.Parallel()
+
+	var tokenCalls atomic.Int32
+	var seenAuthorization string
+	var seenPath string
+	var seenPayload wireEvent
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuthorization = r.Header.Get("Authorization")
+		seenPath = r.URL.Path
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&seenPayload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"submissionId":"11111111-1111-4111-8111-111111111111","acceptedCount":1}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		BaseURL: server.URL,
+		TokenProvider: func(context.Context) (string, error) {
+			tokenCalls.Add(1)
+			return "secret-token", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	message := "hello"
+	result, err := client.Submit(context.Background(), Event{
+		Name:      "app.started",
+		Level:     LevelInfo,
+		Timestamp: time.Date(2026, 7, 18, 20, 30, 0, 0, time.UTC),
+		Message:   &message,
+		Context: map[string]any{
+			"attempt": 1,
+			"healthy": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+
+	if tokenCalls.Load() != 1 {
+		t.Fatalf("token provider calls = %d, want 1", tokenCalls.Load())
+	}
+	if seenAuthorization != "Bearer secret-token" {
+		t.Fatalf("Authorization = %q, want Bearer token", seenAuthorization)
+	}
+	if seenPath != singleSubmissionPath {
+		t.Fatalf("path = %q, want %q", seenPath, singleSubmissionPath)
+	}
+	if !isUUID(result.Events[0].ClientEventID) {
+		t.Fatalf("generated client event id %q is not a UUID", result.Events[0].ClientEventID)
+	}
+	if seenPayload.ClientEventID != result.Events[0].ClientEventID {
+		t.Fatalf("request clientEventId = %q, want %q", seenPayload.ClientEventID, result.Events[0].ClientEventID)
+	}
+	if seenPayload.Message == nil || *seenPayload.Message != message {
+		t.Fatalf("message = %#v, want %q", seenPayload.Message, message)
+	}
+	if result.Receipt.AcceptedCount != 1 {
+		t.Fatalf("acceptedCount = %d, want 1", result.Receipt.AcceptedCount)
+	}
+}
+
+func TestClientSubmitBatchUsesBatchEndpointAndFixedToken(t *testing.T) {
+	t.Parallel()
+
+	var seenAuthorization string
+	var seenPayload wireBatch
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuthorization = r.Header.Get("Authorization")
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&seenPayload); err != nil {
+			t.Fatalf("decode batch request: %v", err)
+		}
+		if r.URL.Path != batchSubmissionPath {
+			t.Fatalf("path = %q, want %q", r.URL.Path, batchSubmissionPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"submissionId":"22222222-2222-4222-8222-222222222222","acceptedCount":2}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, TokenProvider: FixedToken("fixed-token")})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	explicitID := "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	remoteMessage := "boom"
+	result, err := client.SubmitBatch(context.Background(), []Event{
+		{
+			ClientEventID: explicitID,
+			Name:          "app.started",
+			Level:         LevelInfo,
+			Timestamp:     time.Date(2026, 7, 18, 20, 31, 0, 0, time.UTC),
+			Context:       map[string]any{"host": "api-1"},
+			Payload:       []byte("payload"),
+		},
+		{
+			Name:      "app.failed",
+			Level:     LevelError,
+			Timestamp: time.Date(2026, 7, 18, 20, 32, 0, 0, time.UTC),
+			Context:   map[string]any{"retry": false},
+			Error: &RemoteError{
+				Type:       "java.lang.IllegalStateException",
+				Message:    &remoteMessage,
+				Stacktrace: "stack",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SubmitBatch() error = %v", err)
+	}
+
+	if seenAuthorization != "Bearer fixed-token" {
+		t.Fatalf("Authorization = %q, want fixed token", seenAuthorization)
+	}
+	if len(seenPayload.Events) != 2 {
+		t.Fatalf("encoded events = %d, want 2", len(seenPayload.Events))
+	}
+	if seenPayload.Events[0].ClientEventID != explicitID {
+		t.Fatalf("explicit clientEventId = %q, want %q", seenPayload.Events[0].ClientEventID, explicitID)
+	}
+	if got := base64.StdEncoding.EncodeToString(seenPayload.Events[0].PayloadBase64); got != "cGF5bG9hZA==" {
+		t.Fatalf("payloadBase64 = %q, want cGF5bG9hZA==", got)
+	}
+	if seenPayload.Events[1].Error == nil || seenPayload.Events[1].Error.Type != "java.lang.IllegalStateException" {
+		t.Fatalf("error payload = %#v, want remote error", seenPayload.Events[1].Error)
+	}
+	if result.Receipt.AcceptedCount != 2 {
+		t.Fatalf("acceptedCount = %d, want 2", result.Receipt.AcceptedCount)
+	}
+	if len(result.Events) != 2 || !isUUID(result.Events[1].ClientEventID) {
+		t.Fatalf("normalized events = %#v, want generated second client event id", result.Events)
+	}
+}

--- a/client-go/doc.go
+++ b/client-go/doc.go
@@ -1,0 +1,6 @@
+// Package sidecarclient implements a Go client for the observability sidecar API.
+//
+// The direct client posts events to the sidecar over HTTP. The optional outbox
+// client durably appends submissions to a single-process local journal before
+// delivery, then replays them in order with at-least-once semantics.
+package sidecarclient

--- a/client-go/errors.go
+++ b/client-go/errors.go
@@ -1,0 +1,45 @@
+package sidecarclient
+
+import "fmt"
+
+// HTTPError captures a non-202 sidecar response.
+type HTTPError struct {
+	StatusCode int
+	Problem    *Problem
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Problem != nil {
+		if e.Problem.Detail != "" {
+			return fmt.Sprintf("sidecar returned %d %s: %s", e.StatusCode, e.Problem.Title, e.Problem.Detail)
+		}
+		return fmt.Sprintf("sidecar returned %d %s", e.StatusCode, e.Problem.Title)
+	}
+	if e.Body != "" {
+		return fmt.Sprintf("sidecar returned %d: %s", e.StatusCode, e.Body)
+	}
+	return fmt.Sprintf("sidecar returned %d", e.StatusCode)
+}
+
+// OutboxFullError reports explicit bounded-capacity exhaustion.
+type OutboxFullError struct {
+	CapacityBytes  int64
+	UsedBytes      int64
+	AttemptedBytes int64
+}
+
+func (e *OutboxFullError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf(
+		"outbox capacity exceeded: capacity=%d used=%d attempted=%d",
+		e.CapacityBytes,
+		e.UsedBytes,
+		e.AttemptedBytes,
+	)
+}

--- a/client-go/go.mod
+++ b/client-go/go.mod
@@ -1,3 +1,3 @@
 module github.com/janhaesen/observability/client-go
 
-go 1.24.0
+go 1.26.5

--- a/client-go/go.mod
+++ b/client-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/janhaesen/observability/client-go
+
+go 1.24.0

--- a/client-go/outbox.go
+++ b/client-go/outbox.go
@@ -1,0 +1,579 @@
+package sidecarclient
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	defaultCompactThresholdBytes int64 = 1 << 20
+	journalHeaderBytes                 = 8
+	journalFileName                    = "outbox.journal"
+	stateFileName                      = "outbox.state.json"
+	dlqFileName                        = "outbox.dlq"
+)
+
+// OutboxConfig configures the optional single-process append-only file outbox.
+type OutboxConfig struct {
+	Directory             string
+	CapacityBytes         int64
+	CompactThresholdBytes int64
+}
+
+// OutboxClientConfig combines HTTP and outbox configuration.
+type OutboxClientConfig struct {
+	Client Config
+	Outbox OutboxConfig
+}
+
+// OutboxClient appends submissions locally, then flushes them to the sidecar later.
+type OutboxClient struct {
+	client *Client
+	store  *fileOutbox
+}
+
+// NewOutboxClient creates an outbox-backed sidecar client.
+func NewOutboxClient(cfg OutboxClientConfig) (*OutboxClient, error) {
+	client, err := NewClient(cfg.Client)
+	if err != nil {
+		return nil, err
+	}
+	store, err := newFileOutbox(cfg.Outbox)
+	if err != nil {
+		return nil, err
+	}
+	return &OutboxClient{client: client, store: store}, nil
+}
+
+// Submit appends one event to the durable local outbox.
+func (c *OutboxClient) Submit(ctx context.Context, event Event) (QueuedSubmission, error) {
+	normalized, preparedWireEvent, err := prepareEvent(event)
+	if err != nil {
+		return QueuedSubmission{}, err
+	}
+	status, err := c.store.enqueue(ctx, journalRecord{Version: 1, Events: []wireEvent{preparedWireEvent}})
+	if err != nil {
+		return QueuedSubmission{}, err
+	}
+	return QueuedSubmission{Events: []Event{normalized}, Status: status}, nil
+}
+
+// SubmitBatch appends a batch to the durable local outbox.
+func (c *OutboxClient) SubmitBatch(ctx context.Context, events []Event) (QueuedSubmission, error) {
+	normalized, wireEvents, err := prepareEvents(events)
+	if err != nil {
+		return QueuedSubmission{}, err
+	}
+	status, err := c.store.enqueue(ctx, journalRecord{Version: 1, Events: wireEvents})
+	if err != nil {
+		return QueuedSubmission{}, err
+	}
+	return QueuedSubmission{Events: normalized, Status: status}, nil
+}
+
+// Status reports local queue and DLQ counts.
+func (c *OutboxClient) Status() (OutboxStatus, error) {
+	return c.store.status()
+}
+
+// Flush replays pending submissions in order until drained or a transient failure stops progress.
+func (c *OutboxClient) Flush(ctx context.Context) (FlushResult, error) {
+	return c.store.flush(ctx, c.client)
+}
+
+// Close releases local outbox file handles.
+func (c *OutboxClient) Close() error {
+	if c == nil || c.store == nil {
+		return nil
+	}
+	return c.store.close()
+}
+
+type fileOutbox struct {
+	directory             string
+	journalPath           string
+	statePath             string
+	dlqPath               string
+	capacityBytes         int64
+	compactThresholdBytes int64
+
+	mu        sync.Mutex
+	journal   *os.File
+	ackOffset int64
+}
+
+type outboxState struct {
+	AckOffset int64 `json:"ackOffset"`
+}
+
+type journalRecord struct {
+	Version int         `json:"version"`
+	Events  []wireEvent `json:"events"`
+}
+
+type dlqRecord struct {
+	Version    int         `json:"version"`
+	FailedAt   string      `json:"failedAt"`
+	StatusCode int         `json:"statusCode"`
+	Problem    *Problem    `json:"problem,omitempty"`
+	Body       string      `json:"body,omitempty"`
+	Events     []wireEvent `json:"events"`
+}
+
+type scannedRecord struct {
+	Offset int64
+	Next   int64
+	Record journalRecord
+}
+
+func newFileOutbox(cfg OutboxConfig) (*fileOutbox, error) {
+	if cfg.CapacityBytes <= 0 {
+		return nil, fmt.Errorf("outbox capacityBytes must be greater than 0")
+	}
+	if cfg.Directory == "" {
+		return nil, fmt.Errorf("outbox directory is required")
+	}
+	compactThreshold := cfg.CompactThresholdBytes
+	if compactThreshold <= 0 {
+		compactThreshold = minInt64(defaultCompactThresholdBytes, cfg.CapacityBytes)
+	}
+	if err := os.MkdirAll(cfg.Directory, 0o755); err != nil {
+		return nil, fmt.Errorf("create outbox directory: %w", err)
+	}
+	journalPath := filepath.Join(cfg.Directory, journalFileName)
+	journal, err := os.OpenFile(journalPath, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open outbox journal: %w", err)
+	}
+	outbox := &fileOutbox{
+		directory:             cfg.Directory,
+		journalPath:           journalPath,
+		statePath:             filepath.Join(cfg.Directory, stateFileName),
+		dlqPath:               filepath.Join(cfg.Directory, dlqFileName),
+		capacityBytes:         cfg.CapacityBytes,
+		compactThresholdBytes: compactThreshold,
+		journal:               journal,
+	}
+	if err := outbox.recoverLocked(); err != nil {
+		_ = journal.Close()
+		return nil, err
+	}
+	return outbox, nil
+}
+
+func (o *fileOutbox) close() error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.journal == nil {
+		return nil
+	}
+	err := o.journal.Close()
+	o.journal = nil
+	return err
+}
+
+func (o *fileOutbox) enqueue(_ context.Context, record journalRecord) (OutboxStatus, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if err := o.maybeCompactLocked(false); err != nil {
+		return OutboxStatus{}, err
+	}
+	encoded, err := encodeRecord(record)
+	if err != nil {
+		return OutboxStatus{}, err
+	}
+	journalSize, err := o.sizeLocked()
+	if err != nil {
+		return OutboxStatus{}, err
+	}
+	used := journalSize - o.ackOffset
+	if used+int64(len(encoded)) > o.capacityBytes {
+		if err := o.maybeCompactLocked(true); err != nil {
+			return OutboxStatus{}, err
+		}
+		journalSize, err = o.sizeLocked()
+		if err != nil {
+			return OutboxStatus{}, err
+		}
+		used = journalSize - o.ackOffset
+		if used+int64(len(encoded)) > o.capacityBytes {
+			return OutboxStatus{}, &OutboxFullError{
+				CapacityBytes:  o.capacityBytes,
+				UsedBytes:      used,
+				AttemptedBytes: int64(len(encoded)),
+			}
+		}
+	}
+	if _, err := o.journal.Write(encoded); err != nil {
+		return OutboxStatus{}, fmt.Errorf("append outbox journal: %w", err)
+	}
+	if err := o.journal.Sync(); err != nil {
+		return OutboxStatus{}, fmt.Errorf("sync outbox journal: %w", err)
+	}
+	return o.statusLocked()
+}
+
+func (o *fileOutbox) status() (OutboxStatus, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.statusLocked()
+}
+
+func (o *fileOutbox) flush(ctx context.Context, client *Client) (FlushResult, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	var result FlushResult
+	for {
+		if err := ctx.Err(); err != nil {
+			status, statusErr := o.statusLocked()
+			if statusErr == nil {
+				result.Status = status
+			}
+			if statusErr != nil {
+				return result, errors.Join(err, statusErr)
+			}
+			return result, err
+		}
+		entry, err := o.nextPendingLocked()
+		if err != nil {
+			return result, err
+		}
+		if entry == nil {
+			break
+		}
+		_, submitErr := client.submitPrepared(ctx, entry.Record.Events)
+		if submitErr == nil {
+			if err := o.ackLocked(entry.Next); err != nil {
+				return result, err
+			}
+			result.DeliveredSubmissions++
+			result.DeliveredEvents += len(entry.Record.Events)
+			continue
+		}
+		httpErr := new(HTTPError)
+		if errors.As(submitErr, &httpErr) && isPermanentOutboxFailure(httpErr.StatusCode) {
+			if err := o.appendDLQLocked(entry.Record, httpErr); err != nil {
+				return result, err
+			}
+			if err := o.ackLocked(entry.Next); err != nil {
+				return result, err
+			}
+			result.DeadLetteredSubmissions++
+			result.DeadLetteredEvents += len(entry.Record.Events)
+			continue
+		}
+		status, statusErr := o.statusLocked()
+		if statusErr == nil {
+			result.Status = status
+		}
+		if statusErr != nil {
+			return result, errors.Join(submitErr, statusErr)
+		}
+		return result, submitErr
+	}
+	status, err := o.statusLocked()
+	if err != nil {
+		return result, err
+	}
+	result.Status = status
+	return result, nil
+}
+
+func (o *fileOutbox) recoverLocked() error {
+	truncatedSize, err := scanJournal(o.journal, 0, nil)
+	if err != nil {
+		return err
+	}
+	if err := o.journal.Truncate(truncatedSize); err != nil {
+		return fmt.Errorf("truncate recovered journal: %w", err)
+	}
+	ackOffset, err := loadAckOffset(o.statePath)
+	if err != nil {
+		return err
+	}
+	if ackOffset < 0 || ackOffset > truncatedSize {
+		ackOffset = 0
+	}
+	o.ackOffset = ackOffset
+	return o.persistAckOffsetLocked()
+}
+
+func (o *fileOutbox) nextPendingLocked() (*scannedRecord, error) {
+	var entry *scannedRecord
+	_, err := scanJournal(o.journal, o.ackOffset, func(offset, next int64, record journalRecord) error {
+		entry = &scannedRecord{Offset: offset, Next: next, Record: record}
+		return io.EOF
+	})
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return entry, nil
+}
+
+func (o *fileOutbox) statusLocked() (OutboxStatus, error) {
+	status := OutboxStatus{}
+	size, err := o.sizeLocked()
+	if err != nil {
+		return status, err
+	}
+	status.PendingBytes = maxInt64(size-o.ackOffset, 0)
+	if _, err := scanJournal(o.journal, o.ackOffset, func(_, _ int64, record journalRecord) error {
+		status.PendingSubmissions++
+		status.PendingEvents += len(record.Events)
+		return nil
+	}); err != nil {
+		return status, err
+	}
+	dlqFile, err := os.OpenFile(o.dlqPath, os.O_CREATE|os.O_RDONLY, 0o644)
+	if err != nil {
+		return status, fmt.Errorf("open dlq journal: %w", err)
+	}
+	defer dlqFile.Close()
+	if _, err := scanAnyRecord(dlqFile, 0, func(_ int64, _ int64, payload []byte) error {
+		var record dlqRecord
+		if err := json.Unmarshal(payload, &record); err != nil {
+			return fmt.Errorf("decode dlq record: %w", err)
+		}
+		status.DeadLetterSubmissions++
+		status.DeadLetterEvents += len(record.Events)
+		return nil
+	}); err != nil {
+		return status, err
+	}
+	return status, nil
+}
+
+func (o *fileOutbox) ackLocked(nextOffset int64) error {
+	o.ackOffset = nextOffset
+	if err := o.persistAckOffsetLocked(); err != nil {
+		return err
+	}
+	return o.maybeCompactLocked(false)
+}
+
+func (o *fileOutbox) persistAckOffsetLocked() error {
+	state := outboxState{AckOffset: o.ackOffset}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal outbox state: %w", err)
+	}
+	pendingPath := o.statePath + ".next"
+	if err := os.WriteFile(pendingPath, payload, 0o644); err != nil {
+		return fmt.Errorf("write outbox state: %w", err)
+	}
+	stateFile, err := os.OpenFile(pendingPath, os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("open outbox state: %w", err)
+	}
+	if err := stateFile.Sync(); err != nil {
+		stateFile.Close()
+		return fmt.Errorf("sync outbox state: %w", err)
+	}
+	if err := stateFile.Close(); err != nil {
+		return fmt.Errorf("close outbox state: %w", err)
+	}
+	if err := os.Rename(pendingPath, o.statePath); err != nil {
+		return fmt.Errorf("replace outbox state: %w", err)
+	}
+	return nil
+}
+
+func (o *fileOutbox) appendDLQLocked(record journalRecord, httpErr *HTTPError) error {
+	dlq, err := os.OpenFile(o.dlqPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open dlq journal: %w", err)
+	}
+	defer dlq.Close()
+	encoded, err := encodeRecord(dlqRecord{
+		Version:    1,
+		FailedAt:   time.Now().UTC().Format(time.RFC3339Nano),
+		StatusCode: httpErr.StatusCode,
+		Problem:    httpErr.Problem,
+		Body:       httpErr.Body,
+		Events:     record.Events,
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := dlq.Write(encoded); err != nil {
+		return fmt.Errorf("append dlq journal: %w", err)
+	}
+	if err := dlq.Sync(); err != nil {
+		return fmt.Errorf("sync dlq journal: %w", err)
+	}
+	return nil
+}
+
+func (o *fileOutbox) maybeCompactLocked(force bool) error {
+	if o.ackOffset == 0 {
+		return nil
+	}
+	size, err := o.sizeLocked()
+	if err != nil {
+		return err
+	}
+	if !force && o.ackOffset < o.compactThresholdBytes && o.ackOffset != size {
+		return nil
+	}
+	pendingBytes := maxInt64(size-o.ackOffset, 0)
+	pending := make([]byte, pendingBytes)
+	if pendingBytes > 0 {
+		if _, err := o.journal.ReadAt(pending, o.ackOffset); err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("read pending journal bytes: %w", err)
+		}
+	}
+	compactPath := o.journalPath + ".compact"
+	compactFile, err := os.OpenFile(compactPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("open compact journal: %w", err)
+	}
+	if len(pending) > 0 {
+		if _, err := compactFile.Write(pending); err != nil {
+			compactFile.Close()
+			return fmt.Errorf("write compact journal: %w", err)
+		}
+	}
+	if err := compactFile.Sync(); err != nil {
+		compactFile.Close()
+		return fmt.Errorf("sync compact journal: %w", err)
+	}
+	if err := compactFile.Close(); err != nil {
+		return fmt.Errorf("close compact journal: %w", err)
+	}
+	if err := o.journal.Close(); err != nil {
+		return fmt.Errorf("close journal for compaction: %w", err)
+	}
+	if err := os.Rename(compactPath, o.journalPath); err != nil {
+		return fmt.Errorf("replace compact journal: %w", err)
+	}
+	reopened, err := os.OpenFile(o.journalPath, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("reopen compacted journal: %w", err)
+	}
+	o.journal = reopened
+	o.ackOffset = 0
+	return o.persistAckOffsetLocked()
+}
+
+func (o *fileOutbox) sizeLocked() (int64, error) {
+	info, err := o.journal.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("stat outbox journal: %w", err)
+	}
+	return info.Size(), nil
+}
+
+func loadAckOffset(path string) (int64, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("read outbox state: %w", err)
+	}
+	if len(payload) == 0 {
+		return 0, nil
+	}
+	var state outboxState
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return 0, fmt.Errorf("decode outbox state: %w", err)
+	}
+	return state.AckOffset, nil
+}
+
+func scanJournal(file *os.File, offset int64, visitor func(offset, next int64, record journalRecord) error) (int64, error) {
+	return scanAnyRecord(file, offset, func(recordOffset, next int64, payload []byte) error {
+		if visitor == nil {
+			return nil
+		}
+		var record journalRecord
+		if err := json.Unmarshal(payload, &record); err != nil {
+			return fmt.Errorf("decode journal record at %d: %w", recordOffset, err)
+		}
+		return visitor(recordOffset, next, record)
+	})
+}
+
+func scanAnyRecord(file *os.File, offset int64, visitor func(offset, next int64, payload []byte) error) (int64, error) {
+	info, err := file.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("stat journal: %w", err)
+	}
+	size := info.Size()
+	position := offset
+	var header [journalHeaderBytes]byte
+	for position < size {
+		if size-position < journalHeaderBytes {
+			return position, nil
+		}
+		if _, err := file.ReadAt(header[:], position); err != nil {
+			return position, fmt.Errorf("read journal header at %d: %w", position, err)
+		}
+		payloadSize := int64(binary.BigEndian.Uint64(header[:]))
+		next := position + journalHeaderBytes + payloadSize
+		if payloadSize < 0 || next < position {
+			return position, fmt.Errorf("invalid journal record size at %d", position)
+		}
+		if next > size {
+			return position, nil
+		}
+		payload := make([]byte, payloadSize)
+		if _, err := file.ReadAt(payload, position+journalHeaderBytes); err != nil {
+			return position, fmt.Errorf("read journal payload at %d: %w", position, err)
+		}
+		if visitor != nil {
+			if err := visitor(position, next, payload); err != nil {
+				return next, err
+			}
+		}
+		position = next
+	}
+	return position, nil
+}
+
+func encodeRecord(value any) ([]byte, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("marshal journal record: %w", err)
+	}
+	encoded := make([]byte, journalHeaderBytes+len(payload))
+	binary.BigEndian.PutUint64(encoded[:journalHeaderBytes], uint64(len(payload)))
+	copy(encoded[journalHeaderBytes:], payload)
+	return encoded, nil
+}
+
+func isPermanentOutboxFailure(statusCode int) bool {
+	if statusCode < http.StatusBadRequest || statusCode >= http.StatusInternalServerError {
+		return false
+	}
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusRequestTimeout, http.StatusConflict, http.StatusTooManyRequests:
+		return false
+	default:
+		return true
+	}
+}
+
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/client-go/outbox_test.go
+++ b/client-go/outbox_test.go
@@ -1,0 +1,258 @@
+package sidecarclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestOutboxRecoversQueuedEventsAcrossReopen(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"submissionId":"33333333-3333-4333-8333-333333333333","acceptedCount":1}`))
+	}))
+	defer server.Close()
+
+	dir := testDir(t)
+	client, err := NewOutboxClient(OutboxClientConfig{
+		Client: Config{BaseURL: server.URL},
+		Outbox: OutboxConfig{Directory: dir, CapacityBytes: 64 << 10},
+	})
+	if err != nil {
+		t.Fatalf("NewOutboxClient() error = %v", err)
+	}
+
+	queued, err := client.Submit(context.Background(), sampleEvent("queued.once"))
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	if queued.Status.PendingSubmissions != 1 {
+		t.Fatalf("pending submissions = %d, want 1", queued.Status.PendingSubmissions)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	reopened, err := NewOutboxClient(OutboxClientConfig{
+		Client: Config{BaseURL: server.URL},
+		Outbox: OutboxConfig{Directory: dir, CapacityBytes: 64 << 10},
+	})
+	if err != nil {
+		t.Fatalf("reopen outbox: %v", err)
+	}
+	defer reopened.Close()
+
+	status, err := reopened.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if status.PendingSubmissions != 1 || status.PendingEvents != 1 {
+		t.Fatalf("status = %#v, want one pending submission/event", status)
+	}
+
+	result, err := reopened.Flush(context.Background())
+	if err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if result.DeliveredSubmissions != 1 || result.DeliveredEvents != 1 {
+		t.Fatalf("flush result = %#v, want one delivered submission/event", result)
+	}
+	if result.Status.PendingSubmissions != 0 || result.Status.PendingEvents != 0 {
+		t.Fatalf("post-flush status = %#v, want empty queue", result.Status)
+	}
+}
+
+func TestOutboxMovesPermanent4xxToDLQAndContinues(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"type":"https://example.invalid/problem","title":"invalid-request","status":400,"detail":"bad payload"}`))
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"submissionId":"44444444-4444-4444-8444-444444444444","acceptedCount":1}`))
+	}))
+	defer server.Close()
+
+	dir := testDir(t)
+	client, err := NewOutboxClient(OutboxClientConfig{
+		Client: Config{BaseURL: server.URL},
+		Outbox: OutboxConfig{Directory: dir, CapacityBytes: 64 << 10},
+	})
+	if err != nil {
+		t.Fatalf("NewOutboxClient() error = %v", err)
+	}
+	defer client.Close()
+
+	if _, err := client.Submit(context.Background(), sampleEvent("drop.first")); err != nil {
+		t.Fatalf("Submit(first) error = %v", err)
+	}
+	if _, err := client.Submit(context.Background(), sampleEvent("keep.second")); err != nil {
+		t.Fatalf("Submit(second) error = %v", err)
+	}
+
+	result, err := client.Flush(context.Background())
+	if err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if result.DeadLetteredSubmissions != 1 || result.DeliveredSubmissions != 1 {
+		t.Fatalf("flush result = %#v, want one DLQ and one delivered submission", result)
+	}
+	if result.Status.PendingSubmissions != 0 {
+		t.Fatalf("pending submissions after flush = %d, want 0", result.Status.PendingSubmissions)
+	}
+	if result.Status.DeadLetterSubmissions != 1 || result.Status.DeadLetterEvents != 1 {
+		t.Fatalf("DLQ status = %#v, want one dead-lettered submission/event", result.Status)
+	}
+	assertDLQContainsOneRecord(t, filepath.Join(dir, dlqFileName))
+}
+
+func TestOutboxRetriesTransientFailuresWithoutDropping(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"type":"https://example.invalid/problem","title":"unavailable","status":503,"detail":"retry later"}`))
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"submissionId":"55555555-5555-4555-8555-555555555555","acceptedCount":1}`))
+	}))
+	defer server.Close()
+
+	client, err := NewOutboxClient(OutboxClientConfig{
+		Client: Config{BaseURL: server.URL},
+		Outbox: OutboxConfig{Directory: testDir(t), CapacityBytes: 64 << 10},
+	})
+	if err != nil {
+		t.Fatalf("NewOutboxClient() error = %v", err)
+	}
+	defer client.Close()
+
+	if _, err := client.Submit(context.Background(), sampleEvent("retry.me")); err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+
+	firstResult, err := client.Flush(context.Background())
+	if err == nil {
+		t.Fatal("first Flush() error = nil, want transient failure")
+	}
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("first Flush() error = %v, want HTTP 503", err)
+	}
+	if firstResult.Status.PendingSubmissions != 1 || firstResult.Status.PendingEvents != 1 {
+		t.Fatalf("first flush status = %#v, want one pending submission/event", firstResult.Status)
+	}
+
+	secondResult, err := client.Flush(context.Background())
+	if err != nil {
+		t.Fatalf("second Flush() error = %v", err)
+	}
+	if secondResult.DeliveredSubmissions != 1 || secondResult.Status.PendingSubmissions != 0 {
+		t.Fatalf("second flush result = %#v, want drained queue", secondResult)
+	}
+}
+
+func TestOutboxCapacityErrorsExplicitly(t *testing.T) {
+	t.Parallel()
+
+	dir := testDir(t)
+	client, err := NewOutboxClient(OutboxClientConfig{
+		Client: Config{BaseURL: "http://127.0.0.1:1"},
+		Outbox: OutboxConfig{Directory: dir, CapacityBytes: 1},
+	})
+	if err != nil {
+		t.Fatalf("NewOutboxClient() error = %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.Submit(context.Background(), sampleEvent("too.big"))
+	if err == nil {
+		t.Fatal("Submit() error = nil, want OutboxFullError")
+	}
+	var fullErr *OutboxFullError
+	if !errors.As(err, &fullErr) {
+		t.Fatalf("Submit() error = %v, want OutboxFullError", err)
+	}
+	status, statusErr := client.Status()
+	if statusErr != nil {
+		t.Fatalf("Status() error = %v", statusErr)
+	}
+	if status.PendingSubmissions != 0 || status.PendingBytes != 0 {
+		t.Fatalf("status after rejected submit = %#v, want empty queue", status)
+	}
+}
+
+func sampleEvent(name string) Event {
+	message := "queued"
+	return Event{
+		Name:      name,
+		Level:     LevelInfo,
+		Timestamp: time.Date(2026, 7, 18, 20, 30, 0, 0, time.UTC),
+		Message:   &message,
+		Context:   map[string]any{"attempt": 1},
+	}
+}
+
+func testDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(".", ".client-go-test-")
+	if err != nil {
+		t.Fatalf("MkdirTemp() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	return dir
+}
+
+func assertDLQContainsOneRecord(t *testing.T, path string) {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open(%q) error = %v", path, err)
+	}
+	defer file.Close()
+
+	count := 0
+	_, err = scanAnyRecord(file, 0, func(_ int64, _ int64, payload []byte) error {
+		var record dlqRecord
+		if err := json.Unmarshal(payload, &record); err != nil {
+			return err
+		}
+		count++
+		if record.StatusCode != http.StatusBadRequest {
+			t.Fatalf("record statusCode = %d, want 400", record.StatusCode)
+		}
+		if len(record.Events) != 1 {
+			t.Fatalf("record events = %d, want 1", len(record.Events))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scanAnyRecord() error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("DLQ record count = %d, want 1", count)
+	}
+}

--- a/client-go/token.go
+++ b/client-go/token.go
@@ -1,0 +1,21 @@
+package sidecarclient
+
+import "context"
+
+// TokenProvider resolves a bearer token at request time.
+type TokenProvider func(context.Context) (string, error)
+
+// Token calls the provider.
+func (p TokenProvider) Token(ctx context.Context) (string, error) {
+	if p == nil {
+		return "", nil
+	}
+	return p(ctx)
+}
+
+// FixedToken returns a request-time provider for a static bearer token.
+func FixedToken(token string) TokenProvider {
+	return func(context.Context) (string, error) {
+		return token, nil
+	}
+}

--- a/client-go/types.go
+++ b/client-go/types.go
@@ -1,0 +1,77 @@
+package sidecarclient
+
+import "time"
+
+// Level matches the sidecar OpenAPI event level enum.
+type Level string
+
+const (
+	LevelTrace Level = "TRACE"
+	LevelDebug Level = "DEBUG"
+	LevelInfo  Level = "INFO"
+	LevelWarn  Level = "WARN"
+	LevelError Level = "ERROR"
+)
+
+// Event matches the sidecar OpenAPI event submission schema.
+type Event struct {
+	ClientEventID string
+	Name          string
+	Level         Level
+	Timestamp     time.Time
+	Message       *string
+	Context       map[string]any
+	Payload       []byte
+	Error         *RemoteError
+}
+
+// RemoteError matches the sidecar OpenAPI remote error schema.
+type RemoteError struct {
+	Type       string
+	Message    *string
+	Stacktrace string
+}
+
+// Problem mirrors RFC 7807 responses returned by the sidecar.
+type Problem struct {
+	Type   string `json:"type"`
+	Title  string `json:"title"`
+	Status int    `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// SubmissionReceipt matches the OpenAPI 202 response schema.
+type SubmissionReceipt struct {
+	SubmissionID  string `json:"submissionId"`
+	AcceptedCount int    `json:"acceptedCount"`
+}
+
+// SubmissionResult returns the accepted sidecar receipt and the normalized events.
+type SubmissionResult struct {
+	Receipt SubmissionReceipt
+	Events  []Event
+}
+
+// QueuedSubmission reports the normalized events and resulting outbox status.
+type QueuedSubmission struct {
+	Events []Event
+	Status OutboxStatus
+}
+
+// OutboxStatus summarizes the local outbox and DLQ state.
+type OutboxStatus struct {
+	PendingSubmissions    int
+	PendingEvents         int
+	PendingBytes          int64
+	DeadLetterSubmissions int
+	DeadLetterEvents      int
+}
+
+// FlushResult reports what a flush delivered or moved to the DLQ.
+type FlushResult struct {
+	DeliveredSubmissions    int
+	DeliveredEvents         int
+	DeadLetteredSubmissions int
+	DeadLetteredEvents      int
+	Status                  OutboxStatus
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ include(":query-spi")
 include(":benchmarks")
 include(":examples:third-party-sink-example")
 include(":sidecar")
+include(":sidecar-client-jvm")
 
 dependencyResolutionManagement {
     repositories {

--- a/sidecar-client-jvm/api/sidecar-client-jvm.api
+++ b/sidecar-client-jvm/api/sidecar-client-jvm.api
@@ -1,0 +1,62 @@
+public final class io/github/aeshen/observability/sidecar/client/EventSubmission {
+	public static final field Companion Lio/github/aeshen/observability/sidecar/client/EventSubmission$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;)Lio/github/aeshen/observability/sidecar/client/EventSubmission;
+	public static synthetic fun copy$default (Lio/github/aeshen/observability/sidecar/client/EventSubmission;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/aeshen/observability/sidecar/client/EventSubmission;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientEventId ()Ljava/lang/String;
+	public final fun getContext ()Ljava/util/Map;
+	public final fun getLevel ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPayloadBase64 ()Ljava/lang/String;
+	public final fun getTimestamp ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/github/aeshen/observability/sidecar/client/EventSubmission$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/github/aeshen/observability/sidecar/client/EventSubmission$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/github/aeshen/observability/sidecar/client/EventSubmission;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/github/aeshen/observability/sidecar/client/EventSubmission;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/aeshen/observability/sidecar/client/EventSubmission$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/github/aeshen/observability/sidecar/client/FileOutbox : java/lang/AutoCloseable {
+	public fun <init> (Lio/github/aeshen/observability/sidecar/client/SidecarClient;Ljava/nio/file/Path;IJ)V
+	public synthetic fun <init> (Lio/github/aeshen/observability/sidecar/client/SidecarClient;Ljava/nio/file/Path;IJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun enqueue (Lio/github/aeshen/observability/sidecar/client/EventSubmission;)V
+	public final fun flush ()V
+}
+
+public final class io/github/aeshen/observability/sidecar/client/OutboxCapacityException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/github/aeshen/observability/sidecar/client/SidecarClient {
+	public fun <init> (Ljava/net/URI;Lio/github/aeshen/observability/sidecar/client/TokenProvider;Ljava/net/http/HttpClient;)V
+	public synthetic fun <init> (Ljava/net/URI;Lio/github/aeshen/observability/sidecar/client/TokenProvider;Ljava/net/http/HttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun submit (Lio/github/aeshen/observability/sidecar/client/EventSubmission;)V
+}
+
+public abstract interface class io/github/aeshen/observability/sidecar/client/TokenProvider {
+	public abstract fun token ()Ljava/lang/String;
+}
+

--- a/sidecar-client-jvm/build.gradle.kts
+++ b/sidecar-client-jvm/build.gradle.kts
@@ -1,0 +1,28 @@
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+
+plugins {
+    kotlin("jvm") version "2.3.20"
+    kotlin("plugin.serialization") version "2.3.20"
+    `java-library`
+    `maven-publish`
+}
+
+group = rootProject.group
+version = rootProject.version
+
+repositories { mavenCentral() }
+
+dependencies {
+    api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
+    testImplementation(kotlin("test"))
+}
+
+extensions.configure<PublishingExtension> {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            artifactId = "sidecar-client-jvm"
+        }
+    }
+}

--- a/sidecar-client-jvm/src/main/kotlin/io/github/aeshen/observability/sidecar/client/SidecarClient.kt
+++ b/sidecar-client-jvm/src/main/kotlin/io/github/aeshen/observability/sidecar/client/SidecarClient.kt
@@ -1,0 +1,123 @@
+package io.github.aeshen.observability.sidecar.client
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.UUID
+
+private const val ACCEPTED_STATUS = 202
+private const val CLIENT_ERROR_MIN = 400
+private const val CLIENT_ERROR_MAX = 499
+private const val DEFAULT_MAX_EVENTS = 10_000
+private const val DEFAULT_MAX_BYTES = 64L * 1024 * 1024
+
+fun interface TokenProvider {
+    fun token(): String?
+}
+
+@Serializable
+data class EventSubmission(
+    val clientEventId: String = UUID.randomUUID().toString(),
+    val name: String,
+    val level: String,
+    val timestamp: String,
+    val context: Map<String, String> = emptyMap(),
+    val message: String? = null,
+    val payloadBase64: String? = null,
+)
+
+class OutboxCapacityException(message: String) : IllegalStateException(message)
+
+class SidecarClient(
+    private val endpoint: URI,
+    private val tokenProvider: TokenProvider = TokenProvider { null },
+    private val httpClient: HttpClient = HttpClient.newHttpClient(),
+) {
+    fun submit(event: EventSubmission) {
+        val request =
+            HttpRequest
+                .newBuilder(endpoint.resolve("/v1/events"))
+                .header("Content-Type", "application/json")
+                .apply { tokenProvider.token()?.let { header("Authorization", "Bearer $it") } }
+                .POST(HttpRequest.BodyPublishers.ofString(Json.encodeToString(event)))
+                .build()
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.discarding())
+        check(
+            response.statusCode() == ACCEPTED_STATUS,
+        ) { "Sidecar submission failed with status=${response.statusCode()}." }
+    }
+}
+
+class FileOutbox(
+    private val client: SidecarClient,
+    private val directory: Path,
+    private val maxEvents: Int = DEFAULT_MAX_EVENTS,
+    private val maxBytes: Long = DEFAULT_MAX_BYTES,
+) : AutoCloseable {
+    private val journal = directory.resolve("outbox.jsonl")
+    private val deadLetter = directory.resolve("outbox.dlq.jsonl")
+
+    init {
+        require(maxEvents > 0 && maxBytes > 0)
+        Files.createDirectories(directory)
+    }
+
+    @Synchronized
+    fun enqueue(event: EventSubmission) {
+        val line = Json.encodeToString(event) + "\n"
+        val count = if (Files.exists(journal)) Files.readAllLines(journal).size else 0
+        val bytes = if (Files.exists(journal)) Files.size(journal) else 0
+        if (count >= maxEvents || bytes + line.length > maxBytes) {
+            throw OutboxCapacityException("Outbox capacity is exhausted.")
+        }
+        Files.writeString(
+            journal,
+            line,
+            java.nio.file.StandardOpenOption.CREATE,
+            java.nio.file.StandardOpenOption.APPEND,
+        )
+    }
+
+    @Synchronized
+    fun flush() {
+        if (!Files.exists(journal)) return
+        val pending = Files.readAllLines(journal).toMutableList()
+        while (pending.isNotEmpty()) {
+            val line = pending.first()
+            val event = Json.decodeFromString<EventSubmission>(line)
+            try {
+                client.submit(event)
+                pending.removeAt(0)
+                rewrite(pending)
+            } catch (error: IllegalStateException) {
+                if ((CLIENT_ERROR_MIN..CLIENT_ERROR_MAX).any { error.message?.contains("status=$it") == true }) {
+                    Files.writeString(
+                        deadLetter,
+                        "$line\n",
+                        java.nio.file.StandardOpenOption.CREATE,
+                        java.nio.file.StandardOpenOption.APPEND,
+                    )
+                    pending.removeAt(0)
+                    rewrite(pending)
+                } else {
+                    return
+                }
+            }
+        }
+    }
+
+    private fun rewrite(lines: List<String>) {
+        val temporary = directory.resolve("outbox.jsonl.tmp")
+        Files.write(temporary, lines)
+        Files.move(temporary, journal, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+    }
+
+    override fun close() = flush()
+}

--- a/sidecar/src/main/kotlin/io/github/aeshen/observability/sidecar/Main.kt
+++ b/sidecar/src/main/kotlin/io/github/aeshen/observability/sidecar/Main.kt
@@ -204,7 +204,13 @@ class SidecarServer(
     }
 
     private fun parseEvent(input: JsonObject): io.github.aeshen.observability.ObservabilityEvent {
-        input.requireOnly("name", "level", "timestamp", "message", "context", "payloadBase64", "error")
+        input.requireOnly("clientEventId", "name", "level", "timestamp", "message", "context", "payloadBase64", "error")
+        val clientEventId =
+            try {
+                UUID.fromString(input.requiredString("clientEventId"))
+            } catch (_: IllegalArgumentException) {
+                throw RequestValidationException("clientEventId must be a UUID.")
+            }
         val name = input.requiredString("name")
         val level = parseLevel(input.requiredString("level"))
         val timestamp = parseTimestamp(input.requiredString("timestamp"))
@@ -214,7 +220,7 @@ class SidecarServer(
         return event(SubmittedEventName(name)) {
             level(level)
             timestamp(timestamp)
-            context(context.toObservabilityContext())
+            context(context.toObservabilityContext(clientEventId))
             input["message"]?.jsonPrimitive?.contentOrNull?.let(::message)
             payload?.let(::payload)
             remoteError?.let(::error)
@@ -266,8 +272,9 @@ private class RequestValidationException(
 
 private class RequestTooLargeException : RuntimeException()
 
-private fun JsonObject.toObservabilityContext(): ObservabilityContext {
+private fun JsonObject.toObservabilityContext(clientEventId: UUID): ObservabilityContext {
     val builder = ObservabilityContext.builder()
+    builder.put(DynamicContextKey("client_event_id"), clientEventId.toString())
     forEach { (key, value) ->
         val primitive =
             value as? JsonPrimitive ?: throw RequestValidationException(

--- a/sidecar/src/main/openapi/sidecar-v1.yaml
+++ b/sidecar/src/main/openapi/sidecar-v1.yaml
@@ -75,8 +75,11 @@ components:
     EventSubmission:
       type: object
       additionalProperties: false
-      required: [name, level, timestamp, context]
+      required: [clientEventId, name, level, timestamp, context]
       properties:
+        clientEventId:
+          type: string
+          format: uuid
         name:
           type: string
           minLength: 1


### PR DESCRIPTION
- expand issues #50 and #51 with sidecar, SDK, outbox, and delivery requirements
- add a versioned OpenAPI contract for single and atomic batch event submission
- add a runnable sidecar with generated OpenAPI models, authentication, health checks, bounded request admission, and loopback-only unauthenticated binding
- add Docker packaging and GHCR release publishing for the sidecar image
- require client-generated event IDs and preserve them as `client_event_id` for downstream at-least-once deduplication
- upgrade AUDIT_DURABLE to persist events before acceptance and replay unacknowledged records after restart
- add JVM and Go sidecar SDKs with direct submission, request-time token providers, bounded single-process file outboxes, ordered replay, flush/status behavior, and local DLQ routing for permanent sidecar validation failures
- publish the JVM SDK as a Maven artifact and add the Go client module
- update API baselines, reliability terminology, ADRs, changelog, deployment docs, SDK documentation, and repository context
- add sidecar and Go SDK tests and run repository security assessment

Closes: #51

## What changed

<!-- Briefly describe the change and why -->

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs only
- [ ] Build/CI
- [ ] Release prep

## Scope touched

- [ ] Core pipeline (`ObservabilityFactory` / `ObservabilityPipeline`)
- [ ] Providers (`ContextProvider` / `MetadataEnricher` / built-in enrichers)
- [ ] Built-in sinks / decorators / providers
- [ ] SPI contracts (`SinkProvider` / `SinkConfig` / codec / enrichers)
- [ ] Codec / processors / encryption
- [ ] Reliability / diagnostics (`retry`, `batch`, `async`, `ObservabilityDiagnostics`)
- [ ] `:query-spi`
- [ ] `:benchmarks`
- [ ] `:examples:third-party-sink-example`
- [ ] Docs (`README.md`, `docs/*`, module READMEs)

## Validation

- [ ] Added/updated tests
- [x] Ran `./gradlew test`
- [ ] Ran module-specific tests for touched modules (for example `:query-spi:test`, `:examples:third-party-sink-example:test`)
- [x] Ran `./gradlew apiCheck`
- [x] Ran `./gradlew ktlintCheck`
- [x] Ran `./gradlew detekt`
- [ ] Security scan status checked when the change affects dependencies or release surfaces
- [ ] (If applicable) ran benchmark/example module checks

## Compatibility & risk

- [ ] No stable SPI breakage (`docs/spi-contract.md`)
- [ ] If SPI changed, migration notes included
- [ ] Provider ordering/merge behavior reviewed (context + metadata precedence)
- [ ] `AUDIT_DURABLE` behavior reviewed when reliability logic changed
- [ ] Sink failure semantics reviewed when changing delivery/retry behavior

## Docs & release notes

- [ ] Updated root and module docs where user-visible behavior changed (`README.md`, `query-spi/README.md`, `examples/*/README.md`)
- [ ] Updated `CHANGELOG.md` (if needed)
- [ ] Changelog bullets map clearly to affected module(s) and API/SPI/docs impact
- [ ] Synced `agent.md` and `docs/agent/agent.full.md`

## Notes for reviewers

<!-- Anything important to focus on, trade-offs, known limitations -->
